### PR TITLE
feat(serve): add live reload in watch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Added
 
-- Nothing yet.
+- `rustipo serve --watch` now injects live-reload script and auto-refreshes browser after successful rebuilds.
 
 ## [0.2.0] - 2026-03-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,7 +1262,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustipo"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -65,6 +65,7 @@ Current behavior:
 - Default address: `127.0.0.1:3000`
 - Supports custom host/port via `--host` and `--port`
 - Supports watch mode with `--watch` (rebuilds on file changes)
+- In watch mode, injects live-reload script into HTML responses and auto-refreshes browser after successful rebuild
 - Prints local URL on startup
 - Returns readable error if `dist/` does not exist
 

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -30,19 +30,7 @@ This file tracks known implementation debt that should be addressed after the re
 - Priority: High
 - Target: Next quality pass
 
-### 3) `serve --watch` rebuilds but still lacks browser live reload
-
-- Area: dev workflow (`src/commands/serve.rs`, `src/server/*`)
-- Current state: file watch + rebuild works, browser refresh is manual
-- Impact: slower authoring loop than expected from modern static-site workflows
-- Proposed fix:
-  - add optional live-reload endpoint (websocket or SSE)
-  - inject reload script only in serve/dev mode
-  - keep production output unchanged
-- Priority: Medium
-- Target: Post-`0.2.x`
-
-### 4) Shortcode system is intentionally minimal and string-based
+### 3) Shortcode system is intentionally minimal and string-based
 
 - Area: `src/content/markdown.rs`
 - Current state: shortcodes are preprocessed with lightweight parsing and two built-ins (`youtube`, `link`)
@@ -57,7 +45,7 @@ This file tracks known implementation debt that should be addressed after the re
 - Priority: Medium
 - Target: `0.3.0` prep
 
-### 5) Release workflow still needs final validation after merge-strategy change
+### 4) Release workflow still needs final validation after merge-strategy change
 
 - Area: `.github/workflows/release-please.yml`, repo settings
 - Current state: merge policy now preserves commits (rebase/merge-commit), but release flow should be re-verified end-to-end

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -1,4 +1,6 @@
 use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{self, RecvTimeoutError};
 use std::thread;
 use std::time::Duration;
@@ -8,11 +10,18 @@ use notify::{Config, Event, RecommendedWatcher, RecursiveMode, Watcher};
 
 pub fn run(host: &str, port: u16, watch: bool) -> Result<()> {
     let addr = format_addr(host, port);
+    let live_reload_version = if watch {
+        Some(Arc::new(AtomicU64::new(0)))
+    } else {
+        None
+    };
 
     if watch {
         println!("Watch mode enabled");
         crate::commands::build::build_site()?;
-        spawn_watch_thread()?;
+        if let Some(version) = &live_reload_version {
+            spawn_watch_thread(Arc::clone(version))?;
+        }
     }
 
     let runtime = tokio::runtime::Builder::new_current_thread()
@@ -20,14 +29,18 @@ pub fn run(host: &str, port: u16, watch: bool) -> Result<()> {
         .build()
         .context("failed to initialize async runtime for local server")?;
 
-    runtime.block_on(crate::server::serve_dist("dist", &addr))
+    runtime.block_on(crate::server::serve_dist(
+        "dist",
+        &addr,
+        live_reload_version,
+    ))
 }
 
 fn format_addr(host: &str, port: u16) -> String {
     format!("{host}:{port}")
 }
 
-fn spawn_watch_thread() -> Result<()> {
+fn spawn_watch_thread(live_reload_version: Arc<AtomicU64>) -> Result<()> {
     let (tx, rx) = mpsc::channel::<notify::Result<Event>>();
     let mut watcher = RecommendedWatcher::new(
         move |res| {
@@ -66,7 +79,10 @@ fn spawn_watch_thread() -> Result<()> {
 
                     println!("Change detected. Rebuilding...");
                     match crate::commands::build::build_site() {
-                        Ok(_) => println!("Rebuild completed"),
+                        Ok(_) => {
+                            live_reload_version.fetch_add(1, Ordering::SeqCst);
+                            println!("Rebuild completed");
+                        }
                         Err(err) => eprintln!("Rebuild failed: {err}"),
                     }
                 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,10 +1,48 @@
 use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::{Context, Result, bail};
+use axum::Json;
 use axum::Router;
+use axum::body::{Body, to_bytes};
+use axum::http::header::{CONTENT_LENGTH, CONTENT_TYPE};
+use axum::http::{HeaderValue, Response, StatusCode};
+use axum::middleware;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use serde::Serialize;
 use tower_http::services::ServeDir;
 
-pub async fn serve_dist(dist_dir: impl AsRef<Path>, addr: &str) -> Result<()> {
+const MAX_HTML_BYTES: usize = 10 * 1024 * 1024;
+const LIVE_RELOAD_SNIPPET: &str = r#"<script>
+(() => {
+  const endpoint = "/__rustipo_reload";
+  let current = null;
+  async function tick() {
+    try {
+      const response = await fetch(endpoint, { cache: "no-store" });
+      if (!response.ok) return;
+      const payload = await response.json();
+      if (current === null) {
+        current = payload.version;
+        return;
+      }
+      if (payload.version !== current) {
+        window.location.reload();
+      }
+    } catch (_) {}
+  }
+  setInterval(tick, 1000);
+  tick();
+})();
+</script>"#;
+
+pub async fn serve_dist(
+    dist_dir: impl AsRef<Path>,
+    addr: &str,
+    live_reload_version: Option<Arc<AtomicU64>>,
+) -> Result<()> {
     let dist_dir = dist_dir.as_ref();
     if !dist_dir.is_dir() {
         bail!(
@@ -17,7 +55,23 @@ pub async fn serve_dist(dist_dir: impl AsRef<Path>, addr: &str) -> Result<()> {
         .await
         .with_context(|| format!("failed to bind local server at {addr}"))?;
 
-    let app = Router::new().fallback_service(ServeDir::new(dist_dir));
+    let mut app = Router::new().fallback_service(ServeDir::new(dist_dir));
+    if let Some(version) = live_reload_version {
+        let version_for_handler = Arc::clone(&version);
+        app = app
+            .route(
+                "/__rustipo_reload",
+                get(move || {
+                    let version = Arc::clone(&version_for_handler);
+                    async move {
+                        Json(LiveReloadPayload {
+                            version: version.load(Ordering::SeqCst),
+                        })
+                    }
+                }),
+            )
+            .layer(middleware::map_response(inject_live_reload_script));
+    }
 
     println!("Serving dist/ at http://{addr}");
     axum::serve(listener, app)
@@ -27,18 +81,71 @@ pub async fn serve_dist(dist_dir: impl AsRef<Path>, addr: &str) -> Result<()> {
     Ok(())
 }
 
+#[derive(Serialize)]
+struct LiveReloadPayload {
+    version: u64,
+}
+
+async fn inject_live_reload_script(mut response: Response<Body>) -> Response<Body> {
+    if !is_html_response(&response) {
+        return response;
+    }
+
+    let (parts, body) = response.into_parts();
+    let Ok(bytes) = to_bytes(body, MAX_HTML_BYTES).await else {
+        return Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .body(Body::from(
+                "Failed to read HTML response for live reload injection",
+            ))
+            .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response());
+    };
+
+    let Ok(mut html) = String::from_utf8(bytes.to_vec()) else {
+        return Response::from_parts(parts, Body::from(bytes));
+    };
+
+    if html.contains("/__rustipo_reload") {
+        return Response::from_parts(parts, Body::from(html));
+    }
+
+    if let Some(pos) = html.rfind("</body>") {
+        html.insert_str(pos, LIVE_RELOAD_SNIPPET);
+    } else {
+        html.push_str(LIVE_RELOAD_SNIPPET);
+    }
+
+    let len = html.len();
+    response = Response::from_parts(parts, Body::from(html));
+    if let Ok(value) = HeaderValue::from_str(&len.to_string()) {
+        let _ = response.headers_mut().insert(CONTENT_LENGTH, value);
+    }
+    response
+}
+
+fn is_html_response(response: &Response<Body>) -> bool {
+    response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.starts_with("text/html"))
+}
+
 #[cfg(test)]
 mod tests {
+    use axum::body::Body;
+    use axum::http::Response;
+    use axum::http::header::CONTENT_TYPE;
     use tempfile::tempdir;
 
-    use super::serve_dist;
+    use super::{inject_live_reload_script, serve_dist};
 
     #[tokio::test]
     async fn fails_if_dist_directory_is_missing() {
         let dir = tempdir().expect("tempdir should be created");
         let dist = dir.path().join("missing-dist");
 
-        let error = serve_dist(&dist, "127.0.0.1:0")
+        let error = serve_dist(&dist, "127.0.0.1:0", None)
             .await
             .expect_err("missing dist dir should fail");
 
@@ -48,5 +155,38 @@ mod tests {
                 .contains("build output directory not found"),
             "unexpected error: {error}"
         );
+    }
+
+    #[tokio::test]
+    async fn injects_reload_snippet_into_html_response() {
+        let response = Response::builder()
+            .header(CONTENT_TYPE, "text/html; charset=utf-8")
+            .body(Body::from("<html><body><h1>Hello</h1></body></html>"))
+            .expect("response should build");
+
+        let response = inject_live_reload_script(response).await;
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body should read");
+        let html = String::from_utf8(body.to_vec()).expect("body should be utf8");
+
+        assert!(html.contains("/__rustipo_reload"));
+        assert!(html.contains("<h1>Hello</h1>"));
+    }
+
+    #[tokio::test]
+    async fn does_not_inject_into_non_html_response() {
+        let response = Response::builder()
+            .header(CONTENT_TYPE, "application/javascript")
+            .body(Body::from("console.log('hi');"))
+            .expect("response should build");
+
+        let response = inject_live_reload_script(response).await;
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body should read");
+        let text = String::from_utf8(body.to_vec()).expect("body should be utf8");
+
+        assert_eq!(text, "console.log('hi');");
     }
 }


### PR DESCRIPTION
## Summary
- add live reload endpoint and HTML injection for 
- trigger browser auto-refresh only after successful rebuilds
- update CLI/changelog/tech-debt docs

## Validation
- cargo test -q
