### PR TITLE
refactor(core): narrow dead-code allowances

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5,17 +5,19 @@ use anyhow::{Context, Result};
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
-#[allow(dead_code)]
 pub struct SiteConfig {
     pub title: String,
     pub base_url: String,
     pub theme: String,
     pub description: String,
+    // Reserved for template contexts and future metadata outputs.
+    #[allow(dead_code)]
     pub author: Option<AuthorConfig>,
     pub site: Option<SiteOptions>,
 }
 
 #[derive(Debug, Deserialize)]
+// Author keys are accepted in config now even though rendering does not consume them yet.
 #[allow(dead_code)]
 pub struct AuthorConfig {
     pub name: Option<String>,
@@ -25,7 +27,6 @@ pub struct AuthorConfig {
 }
 
 #[derive(Debug, Deserialize)]
-#[allow(dead_code)]
 pub struct SiteOptions {
     pub posts_per_page: Option<usize>,
 }

--- a/src/content/frontmatter.rs
+++ b/src/content/frontmatter.rs
@@ -4,7 +4,6 @@ use gray_matter::{Matter, ParsedEntity};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Default, Deserialize, Serialize)]
-#[allow(dead_code)]
 pub struct Frontmatter {
     pub title: Option<String>,
     pub date: Option<String>,

--- a/src/content/pages/model.rs
+++ b/src/content/pages/model.rs
@@ -11,8 +11,9 @@ pub enum PageKind {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct Page {
+    // Kept for future diagnostics and source-linked features (watch mode, content tracing).
+    #[allow(dead_code)]
     pub source_path: PathBuf,
     pub route: String,
     pub slug: String,

--- a/src/render/templates/mod.rs
+++ b/src/render/templates/mod.rs
@@ -14,7 +14,6 @@ mod section;
 mod tags;
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct RenderedPage {
     pub route: String,
     pub html: String,

--- a/src/theme/models.rs
+++ b/src/theme/models.rs
@@ -3,10 +3,11 @@ use std::path::PathBuf;
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
-#[allow(dead_code)]
 pub struct ThemeMetadata {
     pub name: String,
     pub version: String,
+    // Preserved from theme contract for listing and future template exposure.
+    #[allow(dead_code)]
     pub author: String,
     pub description: String,
     pub extends: Option<String>,
@@ -19,8 +20,9 @@ pub struct ThemeSummary {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct Theme {
+    // Retained for future theme-relative resolution (includes, diagnostics, tooling).
+    #[allow(dead_code)]
     pub root_dir: PathBuf,
     pub template_dirs: Vec<PathBuf>,
     pub static_dirs: Vec<PathBuf>,


### PR DESCRIPTION
## Summary
- remove blanket  annotations from core structs
- keep only targeted allowances on intentionally-unused contract fields
- add rationale comments for each intentional allowance

## Validation
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test -q