### PR TITLE
refactor(content): extract shortcode pipeline into modules

### DIFF
--- a/src/content/markdown.rs
+++ b/src/content/markdown.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::sync::OnceLock;
 
 use pulldown_cmark::{CodeBlockKind, CowStr, Event, Options, Parser, Tag, TagEnd, html};
@@ -7,7 +6,7 @@ use syntect::html::highlighted_html_for_string;
 use syntect::parsing::SyntaxSet;
 
 pub fn render_html(markdown: &str) -> String {
-    let markdown = preprocess_shortcodes(markdown);
+    let markdown = crate::content::shortcodes::preprocess(markdown);
 
     let mut options = Options::empty();
     options.insert(Options::ENABLE_STRIKETHROUGH);
@@ -18,164 +17,6 @@ pub fn render_html(markdown: &str) -> String {
     let mut output = String::new();
     html::push_html(&mut output, parser);
     output
-}
-
-fn preprocess_shortcodes(markdown: &str) -> String {
-    let mut output = String::with_capacity(markdown.len());
-    let mut in_fence = false;
-
-    for line in markdown.split_inclusive('\n') {
-        if line.trim_start().starts_with("```") {
-            in_fence = !in_fence;
-            output.push_str(line);
-            continue;
-        }
-
-        if in_fence {
-            output.push_str(line);
-            continue;
-        }
-
-        output.push_str(&replace_shortcodes_in_text(line));
-    }
-
-    output
-}
-
-fn replace_shortcodes_in_text(input: &str) -> String {
-    let mut output = String::with_capacity(input.len());
-    let mut cursor = 0;
-
-    while let Some(start_rel) = input[cursor..].find("{{<") {
-        let start = cursor + start_rel;
-        output.push_str(&input[cursor..start]);
-
-        let Some(end_rel) = input[start + 3..].find(">}}") else {
-            output.push_str(&input[start..]);
-            return output;
-        };
-        let end = start + 3 + end_rel + 3;
-        let raw = &input[start..end];
-        let inner = input[start + 3..start + 3 + end_rel].trim();
-
-        if let Some(rendered) = render_shortcode(inner) {
-            output.push_str(&rendered);
-        } else {
-            output.push_str(raw);
-        }
-
-        cursor = end;
-    }
-
-    output.push_str(&input[cursor..]);
-    output
-}
-
-fn render_shortcode(input: &str) -> Option<String> {
-    let (name, attrs_raw) = split_shortcode_name_and_attrs(input)?;
-    let attrs = parse_shortcode_attrs(attrs_raw)?;
-
-    match name {
-        "youtube" => {
-            let id = attrs.get("id")?;
-            let id = id.trim();
-            if id.is_empty() {
-                return None;
-            }
-            Some(format!(
-                "<div class=\"rustipo-shortcode rustipo-youtube\"><iframe src=\"https://www.youtube.com/embed/{}\" title=\"YouTube video\" loading=\"lazy\" allowfullscreen></iframe></div>",
-                escape_html(id)
-            ))
-        }
-        "link" => {
-            let href = attrs.get("href")?;
-            let text = attrs.get("text").cloned().unwrap_or_else(|| href.clone());
-            Some(format!(
-                "<a class=\"rustipo-shortcode rustipo-link\" href=\"{}\">{}</a>",
-                escape_html(href),
-                escape_html(&text)
-            ))
-        }
-        _ => None,
-    }
-}
-
-fn split_shortcode_name_and_attrs(input: &str) -> Option<(&str, &str)> {
-    let trimmed = input.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-
-    let mut split_idx = None;
-    for (idx, ch) in trimmed.char_indices() {
-        if ch.is_whitespace() {
-            split_idx = Some(idx);
-            break;
-        }
-    }
-
-    match split_idx {
-        Some(idx) => Some((&trimmed[..idx], trimmed[idx..].trim())),
-        None => Some((trimmed, "")),
-    }
-}
-
-fn parse_shortcode_attrs(input: &str) -> Option<BTreeMap<String, String>> {
-    let mut attrs = BTreeMap::new();
-    let mut index = 0;
-    let bytes = input.as_bytes();
-
-    while index < bytes.len() {
-        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
-            index += 1;
-        }
-        if index >= bytes.len() {
-            break;
-        }
-
-        let key_start = index;
-        while index < bytes.len()
-            && (bytes[index].is_ascii_alphanumeric()
-                || bytes[index] == b'_'
-                || bytes[index] == b'-')
-        {
-            index += 1;
-        }
-        if key_start == index {
-            return None;
-        }
-        let key = &input[key_start..index];
-
-        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
-            index += 1;
-        }
-        if index >= bytes.len() || bytes[index] != b'=' {
-            return None;
-        }
-        index += 1;
-
-        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
-            index += 1;
-        }
-        if index >= bytes.len() || bytes[index] != b'"' {
-            return None;
-        }
-        index += 1;
-
-        let value_start = index;
-        while index < bytes.len() && bytes[index] != b'"' {
-            index += 1;
-        }
-        if index >= bytes.len() {
-            return None;
-        }
-        let value = &input[value_start..index];
-        index += 1;
-
-        attrs.insert(key.to_string(), value.to_string());
-    }
-
-    Some(attrs)
 }
 
 fn replace_code_blocks_with_highlighted_html<'a>(
@@ -285,34 +126,6 @@ mod tests {
         let html = render_html("```rust\nfn main() {}\n```");
         assert!(html.contains("<pre"));
         assert!(html.contains("<span"));
-    }
-
-    #[test]
-    fn renders_youtube_shortcode() {
-        let html = render_html("{{< youtube id=\"dQw4w9WgXcQ\" >}}");
-        assert!(html.contains("youtube.com/embed/dQw4w9WgXcQ"));
-        assert!(html.contains("rustipo-youtube"));
-    }
-
-    #[test]
-    fn renders_link_shortcode() {
-        let html = render_html("{{< link href=\"https://example.com\" text=\"Visit\" >}}");
-        assert!(html.contains("href=\"https://example.com\""));
-        assert!(html.contains(">Visit<"));
-    }
-
-    #[test]
-    fn leaves_unknown_shortcode_as_text() {
-        let html = render_html("{{< unknown foo=\"bar\" >}}");
-        assert!(html.contains("unknown"));
-        assert!(html.contains("foo"));
-        assert!(html.contains("bar"));
-    }
-
-    #[test]
-    fn does_not_render_shortcode_inside_code_fence() {
-        let html = render_html("```\n{{< youtube id=\"dQw4w9WgXcQ\" >}}\n```");
-        assert!(!html.contains("youtube.com/embed/"));
     }
 
     #[test]

--- a/src/content/mod.rs
+++ b/src/content/mod.rs
@@ -3,3 +3,4 @@ pub mod frontmatter;
 pub mod loader;
 pub mod markdown;
 pub mod pages;
+pub mod shortcodes;

--- a/src/content/shortcodes/mod.rs
+++ b/src/content/shortcodes/mod.rs
@@ -1,0 +1,91 @@
+mod parser;
+mod renderer;
+
+use parser::parse_shortcode;
+use renderer::render_shortcode;
+
+pub fn preprocess(markdown: &str) -> String {
+    let mut output = String::with_capacity(markdown.len());
+    let mut in_fence = false;
+
+    for line in markdown.split_inclusive('\n') {
+        if line.trim_start().starts_with("```") {
+            in_fence = !in_fence;
+            output.push_str(line);
+            continue;
+        }
+
+        if in_fence {
+            output.push_str(line);
+            continue;
+        }
+
+        output.push_str(&replace_shortcodes_in_text(line));
+    }
+
+    output
+}
+
+fn replace_shortcodes_in_text(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut cursor = 0;
+
+    while let Some(start_rel) = input[cursor..].find("{{<") {
+        let start = cursor + start_rel;
+        output.push_str(&input[cursor..start]);
+
+        let Some(end_rel) = input[start + 3..].find(">}}") else {
+            output.push_str(&input[start..]);
+            return output;
+        };
+        let end = start + 3 + end_rel + 3;
+        let raw = &input[start..end];
+        let inner = input[start + 3..start + 3 + end_rel].trim();
+
+        if let Some(parsed) = parse_shortcode(inner) {
+            if let Some(rendered) = render_shortcode(&parsed) {
+                output.push_str(&rendered);
+            } else {
+                output.push_str(raw);
+            }
+        } else {
+            output.push_str(raw);
+        }
+
+        cursor = end;
+    }
+
+    output.push_str(&input[cursor..]);
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::preprocess;
+
+    #[test]
+    fn renders_youtube_shortcode() {
+        let html = preprocess("{{< youtube id=\"dQw4w9WgXcQ\" >}}");
+        assert!(html.contains("youtube.com/embed/dQw4w9WgXcQ"));
+        assert!(html.contains("rustipo-youtube"));
+    }
+
+    #[test]
+    fn renders_link_shortcode() {
+        let html = preprocess("{{< link href=\"https://example.com\" text=\"Visit\" >}}");
+        assert!(html.contains("href=\"https://example.com\""));
+        assert!(html.contains(">Visit<"));
+    }
+
+    #[test]
+    fn leaves_unknown_shortcode_as_text() {
+        let html = preprocess("{{< unknown foo=\"bar\" >}}");
+        assert_eq!(html, "{{< unknown foo=\"bar\" >}}");
+    }
+
+    #[test]
+    fn does_not_render_shortcode_inside_code_fence() {
+        let html = preprocess("```\n{{< youtube id=\"dQw4w9WgXcQ\" >}}\n```");
+        assert!(!html.contains("youtube.com/embed/"));
+    }
+}

--- a/src/content/shortcodes/parser.rs
+++ b/src/content/shortcodes/parser.rs
@@ -1,0 +1,93 @@
+use std::collections::BTreeMap;
+
+pub(super) struct ParsedShortcode {
+    pub name: String,
+    pub attrs: BTreeMap<String, String>,
+}
+
+pub(super) fn parse_shortcode(input: &str) -> Option<ParsedShortcode> {
+    let (name, attrs_raw) = split_name_and_attrs(input)?;
+    let attrs = parse_attrs(attrs_raw)?;
+    Some(ParsedShortcode {
+        name: name.to_string(),
+        attrs,
+    })
+}
+
+fn split_name_and_attrs(input: &str) -> Option<(&str, &str)> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let mut split_idx = None;
+    for (idx, ch) in trimmed.char_indices() {
+        if ch.is_whitespace() {
+            split_idx = Some(idx);
+            break;
+        }
+    }
+
+    match split_idx {
+        Some(idx) => Some((&trimmed[..idx], trimmed[idx..].trim())),
+        None => Some((trimmed, "")),
+    }
+}
+
+fn parse_attrs(input: &str) -> Option<BTreeMap<String, String>> {
+    let mut attrs = BTreeMap::new();
+    let mut index = 0;
+    let bytes = input.as_bytes();
+
+    while index < bytes.len() {
+        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+            index += 1;
+        }
+        if index >= bytes.len() {
+            break;
+        }
+
+        let key_start = index;
+        while index < bytes.len()
+            && (bytes[index].is_ascii_alphanumeric()
+                || bytes[index] == b'_'
+                || bytes[index] == b'-')
+        {
+            index += 1;
+        }
+        if key_start == index {
+            return None;
+        }
+        let key = &input[key_start..index];
+
+        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+            index += 1;
+        }
+        if index >= bytes.len() || bytes[index] != b'=' {
+            return None;
+        }
+        index += 1;
+
+        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+            index += 1;
+        }
+        if index >= bytes.len() || bytes[index] != b'"' {
+            return None;
+        }
+        index += 1;
+
+        let value_start = index;
+        while index < bytes.len() && bytes[index] != b'"' {
+            index += 1;
+        }
+        if index >= bytes.len() {
+            return None;
+        }
+        let value = &input[value_start..index];
+        index += 1;
+
+        attrs.insert(key.to_string(), value.to_string());
+    }
+
+    Some(attrs)
+}

--- a/src/content/shortcodes/renderer.rs
+++ b/src/content/shortcodes/renderer.rs
@@ -1,0 +1,42 @@
+use super::parser::ParsedShortcode;
+
+pub(super) fn render_shortcode(shortcode: &ParsedShortcode) -> Option<String> {
+    match shortcode.name.as_str() {
+        "youtube" => render_youtube(shortcode),
+        "link" => render_link(shortcode),
+        _ => None,
+    }
+}
+
+fn render_youtube(shortcode: &ParsedShortcode) -> Option<String> {
+    let id = shortcode.attrs.get("id")?;
+    let id = id.trim();
+    if id.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "<div class=\"rustipo-shortcode rustipo-youtube\"><iframe src=\"https://www.youtube.com/embed/{}\" title=\"YouTube video\" loading=\"lazy\" allowfullscreen></iframe></div>",
+        escape_html(id)
+    ))
+}
+
+fn render_link(shortcode: &ParsedShortcode) -> Option<String> {
+    let href = shortcode.attrs.get("href")?;
+    let text = shortcode
+        .attrs
+        .get("text")
+        .cloned()
+        .unwrap_or_else(|| href.clone());
+    Some(format!(
+        "<a class=\"rustipo-shortcode rustipo-link\" href=\"{}\">{}</a>",
+        escape_html(href),
+        escape_html(&text)
+    ))
+}
+
+fn escape_html(input: &str) -> String {
+    input
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}


### PR DESCRIPTION
## Summary
- move shortcode preprocessing out of `markdown.rs` into `src/content/shortcodes/`
- separate shortcode parsing and rendering responsibilities into dedicated modules
- keep shortcode behavior unchanged while reducing markdown module complexity

## Validation
- cargo fmt
- cargo test -q
- cargo clippy --all-targets --all-features -- -D warnings