### PR TITLE
docs(repo): align docs with current parsing and release behavior

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,7 +30,7 @@ Current behavior:
 - Resolves theme inheritance chain when `extends` is used in `theme.toml`
 - Validates required templates across the resolved theme chain
 - Discovers Markdown files from `content/`
-- Parses frontmatter and excludes drafts
+- Parses frontmatter, validates date format (`YYYY-MM-DD`), and excludes drafts
 - Converts Markdown to HTML
 - Renders supported shortcodes in Markdown content
 - Applies syntax highlighting to fenced code blocks

--- a/docs/content-model.md
+++ b/docs/content-model.md
@@ -28,6 +28,11 @@ Supported fields for MVP:
 
 These frontmatter fields are exposed to page templates under `frontmatter` and page-level convenience keys (for example `page_date`, `page_summary`, `page_tags`).
 
+### Date format
+
+- `date` must use strict `YYYY-MM-DD` format.
+- Invalid dates fail frontmatter parsing with a readable error.
+
 ## URL rules
 
 - `content/index.md` -> `/`

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -24,4 +24,4 @@ This file tracks known implementation debt that should be addressed after the re
   - added tests for empty/default theme-set behavior
 - Release workflow validation after merge-strategy change:
   - completed end-to-end on 2026-03-17 with successful Release Please run
-  - `rustipo-v0.3.0` tag/release published
+  - release flow has continued successfully through `rustipo-v0.3.1`


### PR DESCRIPTION
## Summary
- document strict frontmatter date validation in content model docs
- clarify build frontmatter/date behavior in CLI docs
- refresh tech-debt release validation note to reflect latest successful flow