### PR TITLE
docs(repo): add v0.4.0 scope checklist

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,5 +1,7 @@
 # Roadmap (MVP)
 
+For post-MVP execution, see [v0.4.0 checklist](./v0.4.0-checklist.md).
+
 ## Milestone 1: Foundation
 
 - [x] CLI skeleton (`new`, `build`, `serve`, `theme list`)

--- a/docs/v0.4.0-checklist.md
+++ b/docs/v0.4.0-checklist.md
@@ -1,0 +1,58 @@
+# Rustipo v0.4.0 Checklist
+
+This checklist freezes the next scope to four items only.
+
+## Scope lock
+
+- [ ] Favicon support
+- [ ] Mermaid support
+- [ ] Generic nested custom pages
+- [ ] Theme variants as explicit theme IDs
+
+## Execution order
+
+### 1) Favicon support
+
+- [ ] Support `favicon.ico` and `favicon.svg` from `static/`
+- [ ] Add optional config path (default fallback to `/favicon.ico`)
+- [ ] Inject favicon links in base template context
+- [ ] Fail with readable error if configured favicon is missing
+- [ ] Add tests for asset copy + template output
+
+### 2) Mermaid support
+
+- [ ] Detect fenced code blocks with `mermaid`
+- [ ] Render Mermaid container HTML for those blocks
+- [ ] Keep normal syntax highlighting for non-Mermaid code fences
+- [ ] Inject Mermaid runtime only on pages that use Mermaid
+- [ ] Add tests for render behavior and runtime injection gating
+
+### 3) Generic nested custom pages
+
+- [ ] Support nested routes outside `blog/` and `projects/`
+- [ ] Keep special handling for `blog/` and `projects/` sections
+- [ ] Preserve slug normalization and frontmatter slug override
+- [ ] Add tests for nested route mapping and invalid path handling
+
+### 4) Theme variants (explicit IDs)
+
+- [ ] Define variant naming convention (`family-variant`)
+- [ ] Add initial IDs for Catppuccin and Tokyo Night variants
+- [ ] Ensure `theme list` prints variant IDs clearly
+- [ ] Document recommended variant usage in config
+
+## Out of scope for v0.4.0
+
+- Plugin system
+- Theme registry
+- Full shortcode/plugin API redesign
+- Search ranking improvements
+- i18n
+
+## Release gate
+
+v0.4.0 is ready when:
+
+- [ ] All four scope items above are complete
+- [ ] `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` pass
+- [ ] Docs are updated for all shipped behavior


### PR DESCRIPTION
## Summary
- add a focused v0.4.0 checklist with 4 locked scope items
- define execution order and release gate
- link roadmap doc to the v0.4.0 checklist