### PR TITLE
feat(core): add favicon support to scaffold and build

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -16,6 +16,7 @@ Current behavior:
 
 - Creates starter `content/`, `static/`, and `themes/default/` structure
 - Writes starter `config.toml` and Markdown pages
+- Writes starter `static/favicon.svg` and configures favicon in `config.toml`
 - Writes required default theme templates and starter CSS
 - Fails if target directory already exists
 
@@ -35,6 +36,8 @@ Current behavior:
 - Renders supported shortcodes in Markdown content
 - Applies syntax highlighting to fenced code blocks
 - Renders pages through theme templates
+- Resolves favicon links for template context (`site_favicon*` variables)
+- Fails with a readable error when configured favicon path is missing in `static/`
 - Writes rendered pages to `dist/` using pretty URL output paths
 - Fails with readable error on duplicate rendered output route collisions
 - Copies theme and user static assets into `dist/`

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -13,6 +13,7 @@
     blog/
     projects/
   static/
+    favicon.svg
   themes/
     default/
       templates/

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -15,9 +15,11 @@ pub fn build_site() -> Result<()> {
         "Loaded theme: {} ({})",
         theme.metadata.name, theme.metadata.version
     );
+    let favicon_links = config.resolve_favicon_links(".")?;
     let pages = crate::content::pages::build_pages("content")?;
     println!("Built pages from content: {}", pages.len());
-    let rendered_pages = crate::render::templates::render_pages(&theme, &config, &pages)?;
+    let rendered_pages =
+        crate::render::templates::render_pages(&theme, &config, &pages, &favicon_links)?;
     println!("Rendered pages with templates: {}", rendered_pages.len());
     crate::output::writer::write_rendered_pages("dist", &rendered_pages)?;
     let copied_assets = crate::output::assets::copy_assets_with_collision_check(

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -68,7 +68,18 @@ description = "Default Rustipo theme"
 base_url = "https://example.com"
 theme = "default"
 description = "My personal portfolio site"
+
+[site]
+favicon = "/favicon.svg"
 "#,
+    )?;
+    write_file(
+        &root.join("static/favicon.svg"),
+        r##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#111827"/>
+  <text x="50%" y="54%" text-anchor="middle" font-size="30" font-family="Arial, sans-serif" fill="#ffffff">R</text>
+</svg>
+"##,
     )?;
     write_file(
         &root.join("themes/default/templates/base.html"),
@@ -78,6 +89,10 @@ description = "My personal portfolio site"
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{{ page_title }}</title>
+    {% if site_favicon_svg %}<link rel="icon" href="{{ site_favicon_svg }}" type="image/svg+xml" />{% endif %}
+    {% if site_favicon_ico %}<link rel="icon" href="{{ site_favicon_ico }}" sizes="any" />{% endif %}
+    {% if site_apple_touch_icon %}<link rel="apple-touch-icon" href="{{ site_apple_touch_icon }}" />{% endif %}
+    {% if site_favicon and not site_favicon_svg and not site_favicon_ico %}<link rel="icon" href="{{ site_favicon }}" />{% endif %}
     <link rel="stylesheet" href="/style.css" />
   </head>
   <body>

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,8 +1,8 @@
 use std::fs;
 use std::path::Path;
 
-use anyhow::{Context, Result};
-use serde::Deserialize;
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize)]
 pub struct SiteConfig {
@@ -29,6 +29,7 @@ pub struct AuthorConfig {
 #[derive(Debug, Deserialize)]
 pub struct SiteOptions {
     pub posts_per_page: Option<usize>,
+    pub favicon: Option<String>,
 }
 
 impl SiteConfig {
@@ -38,6 +39,70 @@ impl SiteConfig {
             .and_then(|s| s.posts_per_page)
             .filter(|v| *v > 0)
             .unwrap_or(10)
+    }
+
+    pub fn resolve_favicon_links(&self, project_root: impl AsRef<Path>) -> Result<FaviconLinks> {
+        let project_root = project_root.as_ref();
+        let static_dir = project_root.join("static");
+
+        let mut links = FaviconLinks {
+            icon_href: Some("/favicon.ico".to_string()),
+            ico_href: Some("/favicon.ico".to_string()),
+            svg_href: None,
+            apple_touch_icon_href: None,
+        };
+
+        if static_dir.join("favicon.svg").is_file() {
+            links.svg_href = Some("/favicon.svg".to_string());
+        }
+        if static_dir.join("apple-touch-icon.png").is_file() {
+            links.apple_touch_icon_href = Some("/apple-touch-icon.png".to_string());
+        }
+
+        if let Some(configured) = self
+            .site
+            .as_ref()
+            .and_then(|site| site.favicon.as_deref())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            let href = normalize_favicon_href(configured);
+            let expected = static_dir.join(href.trim_start_matches('/'));
+            if !expected.is_file() {
+                bail!(
+                    "configured favicon file not found: '{}' (expected at '{}')",
+                    href,
+                    expected.display()
+                );
+            }
+
+            links.icon_href = Some(href.clone());
+            if href.ends_with(".svg") {
+                links.svg_href = Some(href);
+            } else if href.ends_with(".ico") {
+                links.ico_href = Some(href);
+            } else if href.ends_with("apple-touch-icon.png") {
+                links.apple_touch_icon_href = Some(href);
+            }
+        }
+
+        Ok(links)
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct FaviconLinks {
+    pub icon_href: Option<String>,
+    pub svg_href: Option<String>,
+    pub ico_href: Option<String>,
+    pub apple_touch_icon_href: Option<String>,
+}
+
+fn normalize_favicon_href(value: &str) -> String {
+    if value.starts_with('/') {
+        value.to_string()
+    } else {
+        format!("/{value}")
     }
 }
 
@@ -51,4 +116,62 @@ pub fn load(path: impl AsRef<Path>) -> Result<SiteConfig> {
         .with_context(|| format!("failed to parse config file: {}", path.display()))?;
 
     Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::{SiteConfig, SiteOptions};
+
+    fn base_config() -> SiteConfig {
+        SiteConfig {
+            title: "Rustipo".to_string(),
+            base_url: "https://example.com".to_string(),
+            theme: "default".to_string(),
+            description: "Portfolio".to_string(),
+            author: None,
+            site: None,
+        }
+    }
+
+    #[test]
+    fn resolves_default_favicon_links() {
+        let dir = tempdir().expect("tempdir should be created");
+        fs::create_dir_all(dir.path().join("static")).expect("static dir should be created");
+        fs::write(dir.path().join("static/favicon.svg"), "<svg/>")
+            .expect("svg favicon should be written");
+
+        let config = base_config();
+        let links = config
+            .resolve_favicon_links(dir.path())
+            .expect("favicon links should resolve");
+
+        assert_eq!(links.ico_href.as_deref(), Some("/favicon.ico"));
+        assert_eq!(links.icon_href.as_deref(), Some("/favicon.ico"));
+        assert_eq!(links.svg_href.as_deref(), Some("/favicon.svg"));
+    }
+
+    #[test]
+    fn fails_when_configured_favicon_is_missing() {
+        let dir = tempdir().expect("tempdir should be created");
+        fs::create_dir_all(dir.path().join("static")).expect("static dir should be created");
+
+        let mut config = base_config();
+        config.site = Some(SiteOptions {
+            posts_per_page: None,
+            favicon: Some("/favicon.ico".to_string()),
+        });
+
+        let error = config
+            .resolve_favicon_links(dir.path())
+            .expect_err("missing favicon should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("configured favicon file not found")
+        );
+    }
 }

--- a/src/render/templates/archive.rs
+++ b/src/render/templates/archive.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use std::collections::BTreeMap;
 use tera::{Context as TeraContext, Tera};
 
-use crate::config::SiteConfig;
+use crate::config::{FaviconLinks, SiteConfig};
 use crate::content::date::ContentDate;
 use crate::content::pages::{Page, PageKind};
 
@@ -28,6 +28,7 @@ pub(super) fn render_blog_archive_page(
     tera: &Tera,
     config: &SiteConfig,
     pages: &[Page],
+    favicon_links: &FaviconLinks,
 ) -> Result<Vec<RenderedPage>> {
     let mut grouped: BTreeMap<String, Vec<ArchiveItem>> = BTreeMap::new();
     let mut all_items = Vec::new();
@@ -76,6 +77,13 @@ pub(super) fn render_blog_archive_page(
     context.insert("archive_groups", &archive_groups);
     context.insert("site_title", &config.title);
     context.insert("site_description", &config.description);
+    context.insert("site_favicon", &favicon_links.icon_href);
+    context.insert("site_favicon_svg", &favicon_links.svg_href);
+    context.insert("site_favicon_ico", &favicon_links.ico_href);
+    context.insert(
+        "site_apple_touch_icon",
+        &favicon_links.apple_touch_icon_href,
+    );
     context.insert("page_title", &format!("Archive | {}", config.title));
     context.insert("content_html", "");
     context.insert("current_page", &1usize);

--- a/src/render/templates/mod.rs
+++ b/src/render/templates/mod.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use tera::Tera;
 use walkdir::WalkDir;
 
-use crate::config::SiteConfig;
+use crate::config::{FaviconLinks, SiteConfig};
 use crate::content::pages::Page;
 use crate::theme::models::Theme;
 
@@ -23,13 +23,24 @@ pub fn render_pages(
     theme: &Theme,
     config: &SiteConfig,
     pages: &[Page],
+    favicon_links: &FaviconLinks,
 ) -> Result<Vec<RenderedPage>> {
     let tera = load_theme_templates(theme)?;
 
-    let mut rendered = page::render_content_pages(&tera, config, pages)?;
-    rendered.extend(section::render_sections(&tera, config, pages)?);
-    rendered.extend(archive::render_blog_archive_page(&tera, config, pages)?);
-    rendered.extend(tags::render_tag_pages(&tera, config, pages)?);
+    let mut rendered = page::render_content_pages(&tera, config, pages, favicon_links)?;
+    rendered.extend(section::render_sections(
+        &tera,
+        config,
+        pages,
+        favicon_links,
+    )?);
+    rendered.extend(archive::render_blog_archive_page(
+        &tera,
+        config,
+        pages,
+        favicon_links,
+    )?);
+    rendered.extend(tags::render_tag_pages(&tera, config, pages, favicon_links)?);
 
     Ok(rendered)
 }

--- a/src/render/templates/page.rs
+++ b/src/render/templates/page.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use tera::{Context as TeraContext, Tera};
 
-use crate::config::SiteConfig;
+use crate::config::{FaviconLinks, SiteConfig};
 use crate::content::pages::{Page, PageKind};
 
 use super::RenderedPage;
@@ -10,6 +10,7 @@ pub(super) fn render_content_pages(
     tera: &Tera,
     config: &SiteConfig,
     pages: &[Page],
+    favicon_links: &FaviconLinks,
 ) -> Result<Vec<RenderedPage>> {
     let mut rendered = Vec::with_capacity(pages.len());
 
@@ -31,6 +32,13 @@ pub(super) fn render_content_pages(
         context.insert("page_order", &page.frontmatter.order);
         context.insert("site_title", &config.title);
         context.insert("site_description", &config.description);
+        context.insert("site_favicon", &favicon_links.icon_href);
+        context.insert("site_favicon_svg", &favicon_links.svg_href);
+        context.insert("site_favicon_ico", &favicon_links.ico_href);
+        context.insert(
+            "site_apple_touch_icon",
+            &favicon_links.apple_touch_icon_href,
+        );
         context.insert(
             "page_title",
             &page

--- a/src/render/templates/section.rs
+++ b/src/render/templates/section.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use serde::Serialize;
 use tera::{Context as TeraContext, Tera};
 
-use crate::config::SiteConfig;
+use crate::config::{FaviconLinks, SiteConfig};
 use crate::content::pages::{Page, PageKind};
 
 use super::RenderedPage;
@@ -19,10 +19,21 @@ pub(super) fn render_sections(
     tera: &Tera,
     config: &SiteConfig,
     pages: &[Page],
+    favicon_links: &FaviconLinks,
 ) -> Result<Vec<RenderedPage>> {
     let mut rendered = Vec::new();
-    rendered.extend(render_blog_section_pages(tera, config, pages)?);
-    rendered.push(render_projects_section_page(tera, config, pages)?);
+    rendered.extend(render_blog_section_pages(
+        tera,
+        config,
+        pages,
+        favicon_links,
+    )?);
+    rendered.push(render_projects_section_page(
+        tera,
+        config,
+        pages,
+        favicon_links,
+    )?);
 
     Ok(rendered)
 }
@@ -31,6 +42,7 @@ fn render_blog_section_pages(
     tera: &Tera,
     config: &SiteConfig,
     pages: &[Page],
+    favicon_links: &FaviconLinks,
 ) -> Result<Vec<RenderedPage>> {
     let items = pages
         .iter()
@@ -86,6 +98,13 @@ fn render_blog_section_pages(
         context.insert("items", &paged_items);
         context.insert("site_title", &config.title);
         context.insert("site_description", &config.description);
+        context.insert("site_favicon", &favicon_links.icon_href);
+        context.insert("site_favicon_svg", &favicon_links.svg_href);
+        context.insert("site_favicon_ico", &favicon_links.ico_href);
+        context.insert(
+            "site_apple_touch_icon",
+            &favicon_links.apple_touch_icon_href,
+        );
         context.insert("page_title", &format!("Blog | {}", config.title));
         context.insert("content_html", "");
         context.insert("current_page", &page_number);
@@ -107,6 +126,7 @@ fn render_projects_section_page(
     tera: &Tera,
     config: &SiteConfig,
     pages: &[Page],
+    favicon_links: &FaviconLinks,
 ) -> Result<RenderedPage> {
     let items = pages
         .iter()
@@ -130,6 +150,13 @@ fn render_projects_section_page(
     context.insert("items", &items);
     context.insert("site_title", &config.title);
     context.insert("site_description", &config.description);
+    context.insert("site_favicon", &favicon_links.icon_href);
+    context.insert("site_favicon_svg", &favicon_links.svg_href);
+    context.insert("site_favicon_ico", &favicon_links.ico_href);
+    context.insert(
+        "site_apple_touch_icon",
+        &favicon_links.apple_touch_icon_href,
+    );
     context.insert("page_title", &format!("Projects | {}", config.title));
     context.insert("content_html", "");
     context.insert("current_page", &1usize);

--- a/src/render/templates/tags.rs
+++ b/src/render/templates/tags.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use std::collections::BTreeMap;
 use tera::{Context as TeraContext, Tera};
 
-use crate::config::SiteConfig;
+use crate::config::{FaviconLinks, SiteConfig};
 use crate::content::pages::{Page, PageKind};
 
 use super::RenderedPage;
@@ -20,6 +20,7 @@ pub(super) fn render_tag_pages(
     tera: &Tera,
     config: &SiteConfig,
     pages: &[Page],
+    favicon_links: &FaviconLinks,
 ) -> Result<Vec<RenderedPage>> {
     let mut tags: BTreeMap<String, Vec<SectionItem>> = BTreeMap::new();
 
@@ -63,6 +64,13 @@ pub(super) fn render_tag_pages(
         context.insert("items", &items);
         context.insert("site_title", &config.title);
         context.insert("site_description", &config.description);
+        context.insert("site_favicon", &favicon_links.icon_href);
+        context.insert("site_favicon_svg", &favicon_links.svg_href);
+        context.insert("site_favicon_ico", &favicon_links.ico_href);
+        context.insert(
+            "site_apple_touch_icon",
+            &favicon_links.apple_touch_icon_href,
+        );
         context.insert("page_title", &format!("Tag: {tag_slug} | {}", config.title));
         context.insert("content_html", "");
 

--- a/src/render/templates/tests.rs
+++ b/src/render/templates/tests.rs
@@ -61,8 +61,12 @@ fn renders_pages_with_theme_templates() {
 
     let pages = build_pages(project_root.join("content")).expect("pages should build");
     let theme = load_active_theme(project_root, "default").expect("theme should load");
+    let favicon_links = config
+        .resolve_favicon_links(project_root)
+        .expect("favicon links should resolve");
 
-    let rendered = render_pages(&theme, &config, &pages).expect("pages should render");
+    let rendered =
+        render_pages(&theme, &config, &pages, &favicon_links).expect("pages should render");
     assert_eq!(rendered.len(), 8);
     assert!(rendered.iter().any(|p| p.route == "/"));
     assert!(rendered.iter().any(|p| p.route == "/blog/post/"));
@@ -124,13 +128,18 @@ fn paginates_blog_section_when_posts_exceed_page_size() {
         author: None,
         site: Some(crate::config::SiteOptions {
             posts_per_page: Some(2),
+            favicon: None,
         }),
     };
 
     let pages = build_pages(project_root.join("content")).expect("pages should build");
     let theme = load_active_theme(project_root, "default").expect("theme should load");
+    let favicon_links = config
+        .resolve_favicon_links(project_root)
+        .expect("favicon links should resolve");
 
-    let rendered = render_pages(&theme, &config, &pages).expect("pages should render");
+    let rendered =
+        render_pages(&theme, &config, &pages, &favicon_links).expect("pages should render");
     assert!(rendered.iter().any(|p| p.route == "/blog/"));
     assert!(rendered.iter().any(|p| p.route == "/blog/page/2/"));
     assert!(rendered.iter().any(|p| p.route == "/blog/archive/"));
@@ -192,7 +201,11 @@ fn renders_archive_groups_for_dated_posts() {
 
     let pages = build_pages(project_root.join("content")).expect("pages should build");
     let theme = load_active_theme(project_root, "default").expect("theme should load");
-    let rendered = render_pages(&theme, &config, &pages).expect("pages should render");
+    let favicon_links = config
+        .resolve_favicon_links(project_root)
+        .expect("favicon links should resolve");
+    let rendered =
+        render_pages(&theme, &config, &pages, &favicon_links).expect("pages should render");
 
     let archive = rendered
         .iter()
@@ -269,7 +282,11 @@ fn exposes_frontmatter_metadata_in_page_templates() {
 
     let pages = build_pages(project_root.join("content")).expect("pages should build");
     let theme = load_active_theme(project_root, "default").expect("theme should load");
-    let rendered = render_pages(&theme, &config, &pages).expect("pages should render");
+    let favicon_links = config
+        .resolve_favicon_links(project_root)
+        .expect("favicon links should resolve");
+    let rendered =
+        render_pages(&theme, &config, &pages, &favicon_links).expect("pages should render");
     let post = rendered
         .iter()
         .find(|page| page.route == "/blog/post/")

--- a/tests/cli_flow.rs
+++ b/tests/cli_flow.rs
@@ -52,7 +52,13 @@ fn new_and_build_generate_expected_output() {
     assert!(project.join("dist/blog/index.html").is_file());
     assert!(project.join("dist/projects/index.html").is_file());
     assert!(project.join("dist/style.css").is_file());
+    assert!(project.join("dist/favicon.svg").is_file());
     assert!(project.join("dist/search-index.json").is_file());
+
+    let index_html =
+        fs::read_to_string(project.join("dist/index.html")).expect("index html should be readable");
+    assert!(index_html.contains("rel=\"icon\""));
+    assert!(index_html.contains("favicon.svg"));
 }
 
 #[test]
@@ -225,6 +231,57 @@ fn build_supports_inherited_theme_overrides() {
 
     let style = fs::read_to_string(root.join("dist/style.css")).expect("style should exist");
     assert_eq!(style, "child-style");
+}
+
+#[test]
+fn build_fails_when_configured_favicon_is_missing() {
+    let dir = tempdir().expect("tempdir should be created");
+    let root = dir.path();
+
+    fs::create_dir_all(root.join("content")).expect("content dir should be created");
+    fs::create_dir_all(root.join("themes/default/templates"))
+        .expect("theme templates should be created");
+    fs::create_dir_all(root.join("themes/default/static")).expect("theme static should be created");
+    fs::create_dir_all(root.join("static")).expect("static dir should be created");
+
+    fs::write(root.join("content/index.md"), "# Home").expect("index should be written");
+    fs::write(
+        root.join("config.toml"),
+        "title = \"Rustipo\"\nbase_url = \"https://example.com\"\ntheme = \"default\"\ndescription = \"Test\"\n\n[site]\nfavicon = \"/favicon.ico\"\n",
+    )
+    .expect("config should be written");
+    fs::write(
+        root.join("themes/default/theme.toml"),
+        "name = \"default\"\nversion = \"0.1.0\"\nauthor = \"Rustipo\"\ndescription = \"Default\"\n",
+    )
+    .expect("theme metadata should be written");
+    for template in [
+        "base.html",
+        "page.html",
+        "post.html",
+        "project.html",
+        "section.html",
+        "index.html",
+    ] {
+        fs::write(
+            root.join("themes/default/templates").join(template),
+            "{% extends \"base.html\" %}{% block body %}{{ content_html | safe }}{% endblock body %}",
+        )
+        .expect("template should be written");
+    }
+    fs::write(
+        root.join("themes/default/templates/base.html"),
+        "{% block body %}{% endblock body %}",
+    )
+    .expect("base template should be written");
+
+    let output = run_cli(root, &["build"]);
+    assert!(!output.status.success(), "build should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("configured favicon file not found"),
+        "unexpected stderr: {stderr}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add favicon resolution to config and build pipeline with readable missing-file errors for configured paths
- inject favicon variables into template render context: `site_favicon`, `site_favicon_svg`, `site_favicon_ico`, `site_apple_touch_icon`
- update `rustipo new` scaffold to generate `static/favicon.svg`, set favicon config, and include favicon link tags in base template
- add unit and integration coverage for favicon behavior and error handling
- refresh CLI and project-structure docs for favicon support

## Validation
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test -q