### PR TITLE
chore(ci): schedule release automation weekly

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,9 +1,10 @@
 name: Release Please
 
 on:
-  push:
-    branches:
-      - master
+  workflow_dispatch:
+  schedule:
+    # Weekly release sweep: Mondays at 09:00 UTC.
+    - cron: "0 9 * * 1"
 
 permissions:
   contents: write

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -5,9 +5,15 @@ Rustipo uses GitHub Actions for continuous integration.
 Workflow file:
 
 - `.github/workflows/ci.yml`
+- `.github/workflows/release-please.yml`
 
 Checks run on push and pull request:
 
 - `cargo fmt -- --check`
 - `cargo clippy --all-targets --all-features -- -D warnings`
 - `cargo test`
+
+## Release cadence
+
+- Release Please is scheduled weekly (Monday 09:00 UTC).
+- Maintainers can run release automation manually via workflow dispatch when needed.


### PR DESCRIPTION
## Summary
- switch Release Please workflow from push-triggered to weekly schedule
- add manual workflow dispatch for maintainers
- document release cadence in CI docs