### PR TITLE
docs(roadmap): update v0.4.0 checklist status

### DIFF
--- a/docs/v0.4.0-checklist.md
+++ b/docs/v0.4.0-checklist.md
@@ -1,23 +1,24 @@
 # Rustipo v0.4.0 Checklist
 
-This checklist freezes the next scope to four items only.
+Historical scope tracker for the original v0.4.0 planning batch.
+Current status is preserved here for traceability.
 
 ## Scope lock
 
-- [ ] Favicon support
+- [x] Favicon support
 - [ ] Mermaid support
 - [ ] Generic nested custom pages
 - [ ] Theme variants as explicit theme IDs
 
 ## Execution order
 
-### 1) Favicon support
+### 1) Favicon support (completed)
 
-- [ ] Support `favicon.ico` and `favicon.svg` from `static/`
-- [ ] Add optional config path (default fallback to `/favicon.ico`)
-- [ ] Inject favicon links in base template context
-- [ ] Fail with readable error if configured favicon is missing
-- [ ] Add tests for asset copy + template output
+- [x] Support `favicon.ico` and `favicon.svg` from `static/`
+- [x] Add optional config path (default fallback to `/favicon.ico`)
+- [x] Inject favicon links in base template context
+- [x] Fail with readable error if configured favicon is missing
+- [x] Add tests for asset copy + template output
 
 ### 2) Mermaid support
 
@@ -51,8 +52,8 @@ This checklist freezes the next scope to four items only.
 
 ## Release gate
 
-v0.4.0 is ready when:
+Original gate for this batch:
 
 - [ ] All four scope items above are complete
-- [ ] `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` pass
-- [ ] Docs are updated for all shipped behavior
+- [x] `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` pass
+- [x] Docs are updated for shipped favicon behavior


### PR DESCRIPTION
## Summary
- mark favicon scope as completed in the historical v0.4.0 checklist
- keep mermaid/nested-pages/theme-variants unchecked (still pending)
- clarify release-gate status lines for traceability