### PR TITLE
docs(roadmap): sync planning docs with shipped features

### DIFF
--- a/docs/mvp-checklist.md
+++ b/docs/mvp-checklist.md
@@ -21,7 +21,10 @@ This checklist is derived from the acceptance criteria in `rustipo_prd.md`.
 
 ## Post-MVP follow-up (tracked separately)
 
-- [ ] Default markdown prose style pack (typography scale, spacing rhythm, code/link/table/blockquote/list/hr styles)
+- [x] Default markdown prose style pack (typography scale, spacing rhythm, code/link/table/blockquote/list/hr styles)
+- [x] Palette system split from layout themes
+- [x] Custom font support for theme/layout typography
+- [x] Default typography refinement after font support
 
 ## Foundation tasks
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,6 +6,17 @@ Core product direction:
 
 - authors write content in Markdown
 - themes provide reusable Tera templates for layout and repeated structure
+- palettes provide color tokens independently from layout themes
+
+Current shipped post-MVP capabilities:
+
+- `rustipo dev` for one-command local development
+- palette selection and built-in presets
+- custom font configuration and local `@font-face` support
+- Mermaid fenced-code rendering
+- nested custom pages outside special sections
+- richer Tera helpers/context for theme authors
+- refined default typography scale and prose rhythm
 
 For historical post-MVP batch planning, see:
 
@@ -55,3 +66,4 @@ For historical post-MVP batch planning, see:
   - more shared context fields
   - more helper functions/filters
   - stronger macro/partial conventions and examples
+- continue growing the layout theme ecosystem now that palette/font foundations are in place

--- a/docs/v0.4.0-checklist.md
+++ b/docs/v0.4.0-checklist.md
@@ -56,6 +56,7 @@ Later product direction moved color presets into a separate palette system.
 
 Original gate for this batch:
 
-- [ ] All four scope items above are complete
+- [x] All four scope items above are complete
 - [x] `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` pass
 - [x] Docs are updated for shipped favicon behavior
+- [x] Historical note added that color presets moved into the palette system


### PR DESCRIPTION
## Summary
- update roadmap and checklists to match the current shipped Rustipo feature set
- mark historical v0.4 and post-MVP items that are already complete
- keep private local PRD changes out of the repo

## Testing
- docs-only change