### PR TITLE
chore(ci): bump release-please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Release Please
         id: release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v4.4.0
         with:
           config-file: .github/release-please/config.json
           manifest-file: .github/release-please/manifest.json


### PR DESCRIPTION
## Summary
- update  to 
- keep the existing manual-only release flow intact

## Verification
- git diff --check

Refs: #1162 upstream node24 tracking