### PR TITLE
chore(ci): opt release workflow into node24

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,9 @@ name: Release Please
 on:
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
## Summary
- opt the release workflow into Node 24 for JavaScript actions
- keep the manual-only Release Please flow unchanged

## Verification
- git diff --check

Refs: GitHub Actions Node 20 deprecation guidance