### PR TITLE
docs(structure): add rustipo site anatomy guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,21 +93,64 @@ style = "normal"
 - Config-driven layout knobs (`content_width`, `top_gap`, `vertical_align`, `line_height`)
 - Optional `static/custom.css` override loaded after theme CSS
 
-## Project Layout
+## Anatomy Of A Rustipo Site
+
+Rustipo projects are organized around a simple model:
+
+- Markdown = content
+- themes = layout
+- palettes = colors
+- static = assets
+- dist = generated output
+
+Typical project layout:
 
 ```text
 my-portfolio/
+  config.toml
   content/
     index.md
     about.md
     resume.md
     blog/
     projects/
+  palettes/
+    dracula.toml
   static/
     fonts/
+    img/
+    js/
+    favicon.svg
+    custom.css
   themes/
-  config.toml
+    default/
+      theme.toml
+      templates/
+      static/
+  dist/
 ```
+
+What each part is for:
+
+- `config.toml` is the main site configuration file
+  - site title, description, theme, palette, layout, and typography live here
+- `content/` is where you write Markdown content
+  - each Markdown file becomes a page
+  - `content/index.md` is the homepage
+  - `content/blog/` is for blog posts
+  - `content/projects/` is for project pages
+  - nested custom pages are supported outside `blog/` and `projects/`
+- `themes/` contains reusable layout themes
+  - `templates/` holds Tera HTML templates
+  - `static/` holds theme CSS and theme assets
+  - `theme.toml` describes the theme
+- `palettes/` is for optional local color palettes
+  - built-in palettes are embedded in Rustipo
+  - local palettes let you add your own color systems with `*.toml`
+- `static/` is for user assets copied into the final site
+  - images, fonts, JavaScript, favicons, and optional `custom.css` belong here
+- `dist/` is generated output
+  - Rustipo recreates it when you build
 
 ## Authoring Model
 

--- a/docs/content-model.md
+++ b/docs/content-model.md
@@ -20,6 +20,20 @@ content/
     *.md
 ```
 
+## Mental model
+
+Rustipo keeps content and presentation separate:
+
+- Markdown files in `content/` are the source of truth for page writing
+- theme templates define reusable layout
+- palettes define color systems
+- static assets are copied into output
+
+In practice:
+
+- content authors mostly work in `content/` and `config.toml`
+- theme authors work in `themes/<theme>/templates/` and `themes/<theme>/static/`
+
 ## Frontmatter fields
 
 Supported fields for MVP:

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -1,5 +1,15 @@
 # Project Structure
 
+## Anatomy Of A Rustipo Site
+
+Rustipo projects are organized around a simple model:
+
+- Markdown = content
+- themes = layout
+- palettes = colors
+- static = assets
+- dist = generated output
+
 ## Generated site scaffold
 
 `rustipo new <site-name>` generates:
@@ -25,15 +35,20 @@
   config.toml
 ```
 
-## Directory purpose
+## What each part is for
 
+- `config.toml`: the main site configuration file
+  - site title, description, selected theme, selected palette, layout settings, and typography settings live here
 - `content/`: Markdown source content for pages, blog posts, and projects
-  - generic custom pages can now be nested (for example `content/notes/rust/tips.md`)
+  - `index.md` is the homepage
+  - standalone pages such as `about.md` and `resume.md` become normal site pages
+  - generic custom pages can be nested (for example `content/notes/rust/tips.md`)
   - nested `index.md` works as a directory index (`content/notes/index.md` -> `/notes/`)
   - `blog/` and `projects/` stay special one-level sections
-- `static/`: user-provided static assets copied to output
-- `static/custom.css` (optional): loaded after theme CSS when present for user overrides
-- `themes/`: theme files (templates + theme assets + metadata)
+- `themes/`: layout themes
+  - `templates/` contains reusable Tera templates
+  - `static/` contains theme CSS and theme assets
+  - `theme.toml` contains theme metadata
 - `palettes/` (optional): local palette overrides and custom color schemes (`*.toml`)
 - built-in palettes are embedded in Rustipo and selectable without copying files into the project:
   - `dracula`
@@ -45,7 +60,20 @@
   - `gruvbox-dark`
   - `tokyonight-storm`
   - `tokyonight-moon`
-- `config.toml`: site-level configuration
-- `config.toml` can define style knobs under `site.layout` and `site.typography` (for example `content_width`, `top_gap`, `vertical_align`, `line_height`, `body_font`, `heading_font`, `mono_font`)
-- local font files can live under `static/fonts/` and be referenced from `[[site.typography.font_faces]]`
+- `static/`: user-provided assets copied into the output
+  - images, fonts, JavaScript files, favicons, and optional `custom.css` belong here
+  - `static/custom.css` (optional) is loaded after theme CSS when present for user overrides
 - `dist/`: generated static output (created by build step)
+
+## Layout and typography configuration
+
+- `config.toml` can define style knobs under `site.layout` and `site.typography`
+- common settings include:
+  - `content_width`
+  - `top_gap`
+  - `vertical_align`
+  - `line_height`
+  - `body_font`
+  - `heading_font`
+  - `mono_font`
+- local font files can live under `static/fonts/` and be referenced from `[[site.typography.font_faces]]`


### PR DESCRIPTION
## Summary
- add a dedicated Rustipo site anatomy section to the README
- explain what each major folder is for in project structure docs
- clarify the content mental model in content docs

## Verification
- git diff --check