### PR TITLE
docs(roadmap): note optional scss evaluation

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -67,3 +67,4 @@ For historical post-MVP batch planning, see:
   - more helper functions/filters
   - stronger macro/partial conventions and examples
 - continue growing the layout theme ecosystem now that palette/font foundations are in place
+- evaluate optional SCSS support for theme authoring while keeping plain CSS as the default


### PR DESCRIPTION
## Summary
- add optional SCSS evaluation as a future roadmap note
- keep it framed as an enhancement, not tech debt

## Verification
- git diff --check

Refs: #53