### PR TITLE
docs(repo): broaden site wording and note shipped outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rustipo
 
-Rustipo is an open-source, themeable static site generator written in Rust for portfolio websites.
+Rustipo is an open-source, themeable static site generator written in Rust for blogs, notes, docs, personal sites, and other Markdown-first websites.
 
 Rustipo is Markdown-first for content authoring and uses Tera templates for reusable layout.
 Rustipo separates layout from color selection: `theme` controls structure, while `palette`
@@ -25,8 +25,8 @@ MVP complete, active post-MVP development.
 ## Quick Start
 
 ```bash
-cargo run -- new my-portfolio
-cd my-portfolio
+cargo run -- new my-site
+cd my-site
 cargo run -- dev
 ```
 
@@ -106,7 +106,7 @@ Rustipo projects are organized around a simple model:
 Typical project layout:
 
 ```text
-my-portfolio/
+my-site/
   config.toml
   content/
     index.md

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -4,12 +4,12 @@ Rustipo provides the following commands.
 
 ## `rustipo new <site-name>`
 
-Creates a new starter portfolio project directory.
+Creates a new starter Rustipo site project directory.
 
 Example:
 
 ```bash
-rustipo new my-portfolio
+rustipo new my-site
 ```
 
 Current behavior:

--- a/docs/mvp-checklist.md
+++ b/docs/mvp-checklist.md
@@ -4,7 +4,7 @@ This checklist is derived from the acceptance criteria in `rustipo_prd.md`.
 
 ## Acceptance criteria
 
-- [x] `rustipo new my-site` creates a usable starter portfolio project
+- [x] `rustipo new my-site` creates a usable starter site project
 - [x] `rustipo build` converts Markdown content into a static site in `dist/`
 - [x] Generated site includes homepage, about, resume, blog, and projects pages
 - [x] Blog and project entries render with frontmatter metadata

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,6 +17,10 @@ Current shipped post-MVP capabilities:
 - nested custom pages outside special sections
 - richer Tera helpers/context for theme authors
 - refined default typography scale and prose rhythm
+- generated publishing/search artifacts during build:
+  - `dist/rss.xml`
+  - `dist/sitemap.xml`
+  - `dist/search-index.json`
 
 For historical post-MVP batch planning, see:
 


### PR DESCRIPTION
## Summary\n- broaden portfolio-heavy wording in README and CLI docs\n- update MVP wording to say starter site project\n- note that RSS, sitemap, and search index are already shipped build outputs\n\n## Testing\n- not needed (docs only)