### PR TITLE
fix(crate): shorten crates.io keyword list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/fcendesu/rustipo"
 homepage = "https://github.com/fcendesu/rustipo"
-keywords = ["static-site-generator", "markdown", "blog", "docs", "tera"]
+keywords = ["ssg", "markdown", "blog", "docs", "tera"]
 categories = ["command-line-utilities", "web-programming"]
 include = [
     "/assets/**",


### PR DESCRIPTION
## Summary
- replace the overlong crates.io keyword with a valid shorter keyword
- keep the crate publishable under crates.io keyword limits

## Validation
- cargo publish --dry-run --allow-dirty
