### PR TITLE
docs(cli): add crates.io install flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,22 @@ MVP complete, active post-MVP development.
 
 ## Quick Start
 
+Install Rustipo:
+
 ```bash
-cargo run -- new my-site
+cargo install rustipo
+```
+
+```bash
+rustipo new my-site
 cd my-site
-cargo run -- dev
+rustipo dev
 ```
 
 Production build:
 
 ```bash
-cargo run -- build
+rustipo build
 ```
 
 ## Layout Without CSS Editing

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,6 +2,12 @@
 
 Rustipo provides the following commands.
 
+## Installation
+
+```bash
+cargo install rustipo
+```
+
 ## `rustipo new <site-name>`
 
 Creates a new starter Rustipo site project directory.


### PR DESCRIPTION
## Summary
- add the crates.io install flow to the README quick start
- add a dedicated installation snippet to the CLI reference

## Validation
- cargo search rustipo --limit 5
