### PR TITLE
docs(cli): refine install and quickstart flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ MVP complete, active post-MVP development.
 - `rustipo theme install <source>`
 - `rustipo deploy github-pages`
 
-## Quick Start
+## Installation And Quick Start
 
 Install Rustipo:
 
@@ -30,16 +30,47 @@ Install Rustipo:
 cargo install rustipo
 ```
 
+Create a site:
+
 ```bash
 rustipo new my-site
 cd my-site
+```
+
+Choose a palette:
+
+```bash
+rustipo palette list
+rustipo palette use catppuccin-mocha
+```
+
+Preview locally:
+
+```bash
 rustipo dev
 ```
 
-Production build:
+Build static output:
 
 ```bash
 rustipo build
+```
+
+Theme discovery:
+
+```bash
+rustipo theme list
+rustipo theme install owner/repo
+```
+
+## Local Development From The Repository
+
+If you are working on Rustipo itself instead of the published crate:
+
+```bash
+cargo run -- new my-site
+cd my-site
+../target/debug/rustipo dev
 ```
 
 ## Layout Without CSS Editing

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -4,8 +4,40 @@ Rustipo provides the following commands.
 
 ## Installation
 
+Published install:
+
 ```bash
 cargo install rustipo
+```
+
+Local development from the repository:
+
+```bash
+cargo install --path .
+```
+
+or
+
+```bash
+cargo run -- --help
+```
+
+## Quick Start
+
+```bash
+rustipo new my-site
+cd my-site
+rustipo palette list
+rustipo palette use catppuccin-mocha
+rustipo dev
+rustipo build
+```
+
+Theme discovery:
+
+```bash
+rustipo theme list
+rustipo theme install owner/repo
 ```
 
 ## `rustipo new <site-name>`


### PR DESCRIPTION
## Summary
- expand the install and quickstart path in the README
- add a clearer published-install and local-development flow to the CLI docs
- include palette and theme discovery in the first-run path

## Testing
- not run (docs only)
