### PR TITLE
fix(deploy): generate valid github pages workflow

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -260,7 +260,8 @@ rustipo deploy github-pages --force
 Current behavior:
 
 - Writes `.github/workflows/deploy-pages.yml`
-- Workflow runs `cargo run -- build` and deploys `dist/` using Pages actions
+- Workflow installs Rustipo from crates.io with `cargo install rustipo --locked`
+- Workflow runs `rustipo build` and deploys `dist/` using Pages actions
 - Refuses to overwrite existing workflow unless `--force` is provided
 
 ## Style Options (`config.toml`)

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -29,8 +29,11 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install Rustipo
+        run: cargo install rustipo --locked
+
       - name: Build Site
-        run: cargo run -- build
+        run: rustipo build
 
       - name: Configure Pages
         uses: actions/configure-pages@v5

--- a/tests/cli_flow.rs
+++ b/tests/cli_flow.rs
@@ -500,6 +500,9 @@ fn deploy_github_pages_generates_workflow_file() {
     let content = fs::read_to_string(workflow).expect("workflow should be readable");
     assert!(content.contains("name: Deploy GitHub Pages"));
     assert!(content.contains("actions/deploy-pages@v4"));
+    assert!(content.contains("cargo install rustipo --locked"));
+    assert!(content.contains("run: rustipo build"));
+    assert!(!content.contains("cargo run -- build"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- make the generated GitHub Pages workflow install the published Rustipo binary
- build Pages sites with `rustipo build` instead of `cargo run -- build`
- strengthen deploy helper tests to assert the workflow content matches the normal site model

## Validation
- cargo test -q
- cargo fmt --all --check
- cargo clippy --all-targets --all-features -- -D warnings
