### PR TITLE
feat(cli): add rustipo check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ MVP complete, active post-MVP development.
 ## CLI
 
 - `rustipo new <site-name>`
+- `rustipo check`
 - `rustipo dev`
 - `rustipo build`
 - `rustipo serve`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -33,12 +33,34 @@ rustipo dev
 rustipo build
 ```
 
+Project validation:
+
+```bash
+rustipo check
+```
+
 Theme discovery:
 
 ```bash
 rustipo theme list
 rustipo theme install owner/repo
 ```
+
+## `rustipo check`
+
+Validates project inputs without writing build output.
+
+Current behavior:
+
+- Loads and validates `config.toml`
+- Loads the active theme and selected palette
+- Validates configured favicon and local font assets
+- Parses Markdown content and frontmatter
+- Renders pages through the theme templates
+- Validates rendered route/output collisions
+- Validates generated `palette.css` would not collide with site or theme assets
+- Validates theme and user static asset paths would not collide
+- Exits with non-zero status when validation fails
 
 ## `rustipo new <site-name>`
 

--- a/docs/implemented-features.md
+++ b/docs/implemented-features.md
@@ -3,6 +3,7 @@
 ## CLI
 
 - `rustipo new <site-name>`
+- `rustipo check`
 - `rustipo build`
 - `rustipo dev`
   - `--host`
@@ -395,4 +396,3 @@
 - invalid palette ID detection
 - invalid palette token name detection
 - missing `dist/` error on serve
-

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,6 +15,8 @@ pub struct Cli {
 pub enum Commands {
     /// Create a new site scaffold
     New { site_name: String },
+    /// Validate config, content, themes, palettes, and routes without writing output
+    Check,
     /// Build the site into dist/
     Build,
     /// Build, serve, and watch the site during development
@@ -106,6 +108,16 @@ mod tests {
                 assert_eq!(port, 4000);
             }
             other => panic!("expected dev command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_check_command() {
+        let cli = Cli::parse_from(["rustipo", "check"]);
+
+        match cli.command {
+            Commands::Check => {}
+            other => panic!("expected check command, got {other:?}"),
         }
     }
 

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -13,63 +13,30 @@ pub fn build_site_quiet() -> Result<()> {
 }
 
 fn build_site_with_logging(verbose: bool) -> Result<()> {
-    let config = crate::config::load("config.toml")?;
-    if verbose {
-        println!(
-            "Loaded config: title='{}', theme='{}', palette='{}'",
-            config.title,
-            config.theme,
-            config.selected_palette()
-        );
-    }
-    let theme = crate::theme::loader::load_active_theme(".", &config.theme)?;
-    let palette = crate::palette::loader::load_palette(".", config.selected_palette())?;
-    if verbose {
-        println!(
-            "Loaded theme: {} ({})",
-            theme.metadata.name, theme.metadata.version
-        );
-        println!("Loaded palette: {}", palette.name);
-    }
-    let favicon_links = config.resolve_favicon_links(".")?;
-    let site_style = config.style_options();
-    let (_site_fonts, font_faces) = config.resolve_fonts(".", &theme.static_dirs)?;
-    let site_font_faces_css =
-        (!font_faces.is_empty()).then(|| crate::config::fonts::render_font_faces_css(&font_faces));
-    let site_has_custom_css = config.has_custom_css(".");
-    let pages = crate::content::pages::build_pages("content")?;
-    if verbose {
-        println!("Built pages from content: {}", pages.len());
-    }
-    let rendered_pages = crate::render::templates::render_pages(
-        &theme,
-        &config,
-        &pages,
-        &crate::render::templates::SiteRenderContext {
-            favicon_links: &favicon_links,
-            site_style: &site_style,
-            site_has_custom_css,
-            site_font_faces_css: site_font_faces_css.as_deref(),
-            palette: &palette,
-        },
+    let prepared = crate::commands::site::prepare_site(verbose)?;
+    crate::output::writer::write_rendered_pages("dist", &prepared.rendered_pages)?;
+    crate::output::palette::ensure_palette_output_path_available(
+        "static",
+        &prepared.theme.static_dirs,
     )?;
-    if verbose {
-        println!("Rendered pages with templates: {}", rendered_pages.len());
-    }
-    crate::output::writer::write_rendered_pages("dist", &rendered_pages)?;
-    crate::output::palette::ensure_palette_output_path_available("static", &theme.static_dirs)?;
-    crate::output::palette::write_palette_css("dist", &palette)?;
+    crate::output::palette::write_palette_css("dist", &prepared.palette)?;
     let copied_assets = crate::output::assets::copy_assets_with_collision_check(
         "static",
-        &theme.static_dirs,
+        &prepared.theme.static_dirs,
         "dist",
     )?;
-    let rss_items = crate::output::rss::write_rss_feed("dist", &config, &pages)?;
-    let search_documents = crate::output::search::write_search_index("dist", &pages)?;
-    let sitemap_urls =
-        crate::output::sitemap::write_sitemap("dist", &config.base_url, &rendered_pages)?;
+    let rss_items = crate::output::rss::write_rss_feed("dist", &prepared.config, &prepared.pages)?;
+    let search_documents = crate::output::search::write_search_index("dist", &prepared.pages)?;
+    let sitemap_urls = crate::output::sitemap::write_sitemap(
+        "dist",
+        &prepared.config.base_url,
+        &prepared.rendered_pages,
+    )?;
     if verbose {
-        println!("Generated palette CSS: dist/palette.css ({})", palette.id);
+        println!(
+            "Generated palette CSS: dist/palette.css ({})",
+            prepared.palette.id
+        );
         println!("Copied assets: {}", copied_assets);
         println!("Generated RSS items: {}", rss_items);
         println!("Generated search documents: {}", search_documents);

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -1,0 +1,20 @@
+use anyhow::Result;
+
+pub fn run() -> Result<()> {
+    let prepared = crate::commands::site::prepare_site(true)?;
+    let rendered_routes = crate::output::writer::validate_rendered_pages(&prepared.rendered_pages)?;
+    crate::output::palette::ensure_palette_output_path_available(
+        "static",
+        &prepared.theme.static_dirs,
+    )?;
+    let asset_count = crate::output::assets::validate_assets_with_collision_check(
+        "static",
+        &prepared.theme.static_dirs,
+    )?;
+
+    println!("Validated rendered routes: {}", rendered_routes);
+    println!("Validated asset paths: {}", asset_count);
+    println!("Check completed: project inputs are valid.");
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,7 +1,9 @@
 pub mod build;
+pub mod check;
 pub mod deploy;
 pub mod dev;
 pub mod new;
 pub mod palette;
 pub mod serve;
+pub mod site;
 pub mod theme;

--- a/src/commands/site.rs
+++ b/src/commands/site.rs
@@ -1,0 +1,72 @@
+use anyhow::Result;
+
+use crate::config::SiteConfig;
+use crate::content::pages::Page;
+use crate::palette::models::Palette;
+use crate::render::templates::RenderedPage;
+use crate::theme::models::Theme;
+
+pub(crate) struct PreparedSite {
+    pub config: SiteConfig,
+    pub theme: Theme,
+    pub palette: Palette,
+    pub pages: Vec<Page>,
+    pub rendered_pages: Vec<RenderedPage>,
+}
+
+pub(crate) fn prepare_site(verbose: bool) -> Result<PreparedSite> {
+    let config = crate::config::load("config.toml")?;
+    if verbose {
+        println!(
+            "Loaded config: title='{}', theme='{}', palette='{}'",
+            config.title,
+            config.theme,
+            config.selected_palette()
+        );
+    }
+
+    let theme = crate::theme::loader::load_active_theme(".", &config.theme)?;
+    let palette = crate::palette::loader::load_palette(".", config.selected_palette())?;
+    if verbose {
+        println!(
+            "Loaded theme: {} ({})",
+            theme.metadata.name, theme.metadata.version
+        );
+        println!("Loaded palette: {}", palette.name);
+    }
+
+    let favicon_links = config.resolve_favicon_links(".")?;
+    let site_style = config.style_options();
+    let (_site_fonts, font_faces) = config.resolve_fonts(".", &theme.static_dirs)?;
+    let site_font_faces_css =
+        (!font_faces.is_empty()).then(|| crate::config::fonts::render_font_faces_css(&font_faces));
+    let site_has_custom_css = config.has_custom_css(".");
+    let pages = crate::content::pages::build_pages("content")?;
+    if verbose {
+        println!("Built pages from content: {}", pages.len());
+    }
+
+    let rendered_pages = crate::render::templates::render_pages(
+        &theme,
+        &config,
+        &pages,
+        &crate::render::templates::SiteRenderContext {
+            favicon_links: &favicon_links,
+            site_style: &site_style,
+            site_has_custom_css,
+            site_font_faces_css: site_font_faces_css.as_deref(),
+            palette: &palette,
+        },
+    )?;
+    if verbose {
+        println!("Rendered pages with templates: {}", rendered_pages.len());
+    }
+
+    Ok(PreparedSite {
+        config,
+        theme,
+        palette,
+        pages,
+        rendered_pages,
+    })
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ fn main() -> Result<()> {
 
     match cli.command {
         cli::Commands::New { site_name } => commands::new::run(&site_name),
+        cli::Commands::Check => commands::check::run(),
         cli::Commands::Build => commands::build::run(),
         cli::Commands::Dev { host, port } => commands::dev::run(&host, port),
         cli::Commands::Serve { host, port, watch } => commands::serve::run(&host, port, watch),

--- a/src/output/assets.rs
+++ b/src/output/assets.rs
@@ -11,27 +11,22 @@ pub fn copy_assets_with_collision_check(
     theme_static_dirs: &[PathBuf],
     dist_dir: impl AsRef<Path>,
 ) -> Result<usize> {
-    let user_static_dir = user_static_dir.as_ref();
     let dist_dir = dist_dir.as_ref();
-
-    let user_files = collect_relative_files(user_static_dir)?;
-    let mut theme_files = BTreeMap::new();
-    for theme_dir in theme_static_dirs {
-        let rel_files = collect_relative_files(theme_dir)?;
-        for rel in rel_files {
-            theme_files.insert(rel.clone(), theme_dir.join(rel));
-        }
-    }
-
-    if let Some(rel) = user_files.iter().find(|rel| theme_files.contains_key(*rel)) {
-        bail!("asset path collision detected: {}", rel.display());
-    }
+    let prepared = prepare_asset_maps(user_static_dir.as_ref(), theme_static_dirs)?;
 
     let mut copied = 0;
-    copied += copy_files_from_map(dist_dir, &theme_files)?;
-    copied += copy_files(user_static_dir, dist_dir, &user_files)?;
+    copied += copy_files_from_map(dist_dir, &prepared.theme_files)?;
+    copied += copy_files(prepared.user_static_dir, dist_dir, &prepared.user_files)?;
 
     Ok(copied)
+}
+
+pub fn validate_assets_with_collision_check(
+    user_static_dir: impl AsRef<Path>,
+    theme_static_dirs: &[PathBuf],
+) -> Result<usize> {
+    let prepared = prepare_asset_maps(user_static_dir.as_ref(), theme_static_dirs)?;
+    Ok(prepared.user_files.len() + prepared.theme_files.len())
 }
 
 fn copy_files_from_map(dist_dir: &Path, files: &BTreeMap<PathBuf, PathBuf>) -> Result<usize> {
@@ -84,6 +79,36 @@ fn collect_relative_files(root: &Path) -> Result<HashSet<PathBuf>> {
     }
 
     Ok(files)
+}
+
+struct PreparedAssetMaps<'a> {
+    user_static_dir: &'a Path,
+    user_files: HashSet<PathBuf>,
+    theme_files: BTreeMap<PathBuf, PathBuf>,
+}
+
+fn prepare_asset_maps<'a>(
+    user_static_dir: &'a Path,
+    theme_static_dirs: &[PathBuf],
+) -> Result<PreparedAssetMaps<'a>> {
+    let user_files = collect_relative_files(user_static_dir)?;
+    let mut theme_files = BTreeMap::new();
+    for theme_dir in theme_static_dirs {
+        let rel_files = collect_relative_files(theme_dir)?;
+        for rel in rel_files {
+            theme_files.insert(rel.clone(), theme_dir.join(rel));
+        }
+    }
+
+    if let Some(rel) = user_files.iter().find(|rel| theme_files.contains_key(*rel)) {
+        bail!("asset path collision detected: {}", rel.display());
+    }
+
+    Ok(PreparedAssetMaps {
+        user_static_dir,
+        user_files,
+        theme_files,
+    })
 }
 
 fn copy_files(root: &Path, dist_dir: &Path, files: &HashSet<PathBuf>) -> Result<usize> {

--- a/src/output/writer.rs
+++ b/src/output/writer.rs
@@ -16,21 +16,10 @@ pub fn write_rendered_pages(dist_dir: impl AsRef<Path>, pages: &[RenderedPage]) 
     fs::create_dir_all(dist_dir)
         .with_context(|| format!("failed to create output directory: {}", dist_dir.display()))?;
 
-    let mut outputs = Vec::with_capacity(pages.len());
-    let mut seen_output_paths: HashMap<PathBuf, String> = HashMap::new();
-    for page in pages {
-        let output_path = route_to_output_path(dist_dir, &page.route)?;
-        if let Some(existing_route) =
-            seen_output_paths.insert(output_path.clone(), page.route.clone())
-        {
-            bail!(
-                "duplicate output route collision: '{}' and '{}' both map to '{}'",
-                existing_route,
-                page.route,
-                output_path.display()
-            );
-        }
-        outputs.push((output_path, page.html.as_str()));
+    let output_routes = collect_output_routes(pages)?;
+    let mut outputs = Vec::with_capacity(output_routes.len());
+    for (page, rel_path) in pages.iter().zip(output_routes.iter()) {
+        outputs.push((dist_dir.join(rel_path), page.html.as_str()));
     }
 
     for (output_path, html) in outputs {
@@ -46,17 +35,43 @@ pub fn write_rendered_pages(dist_dir: impl AsRef<Path>, pages: &[RenderedPage]) 
     Ok(())
 }
 
-fn route_to_output_path(dist_dir: &Path, route: &str) -> Result<PathBuf> {
+pub fn validate_rendered_pages(pages: &[RenderedPage]) -> Result<usize> {
+    let output_routes = collect_output_routes(pages)?;
+    Ok(output_routes.len())
+}
+
+fn collect_output_routes(pages: &[RenderedPage]) -> Result<Vec<PathBuf>> {
+    let mut outputs = Vec::with_capacity(pages.len());
+    let mut seen_output_paths: HashMap<PathBuf, String> = HashMap::new();
+    for page in pages {
+        let output_path = route_to_output_path(&page.route)?;
+        if let Some(existing_route) =
+            seen_output_paths.insert(output_path.clone(), page.route.clone())
+        {
+            bail!(
+                "duplicate output route collision: '{}' and '{}' both map to '{}'",
+                existing_route,
+                page.route,
+                output_path.display()
+            );
+        }
+        outputs.push(output_path);
+    }
+
+    Ok(outputs)
+}
+
+fn route_to_output_path(route: &str) -> Result<PathBuf> {
     if !route.starts_with('/') || !route.ends_with('/') {
         bail!("route must start and end with '/': {route}");
     }
 
     let trimmed = route.trim_matches('/');
     if trimmed.is_empty() {
-        return Ok(dist_dir.join("index.html"));
+        return Ok(PathBuf::from("index.html"));
     }
 
-    Ok(dist_dir.join(trimmed).join("index.html"))
+    Ok(PathBuf::from(trimmed).join("index.html"))
 }
 
 #[cfg(test)]

--- a/tests/cli_flow.rs
+++ b/tests/cli_flow.rs
@@ -91,6 +91,64 @@ fn new_and_build_generate_expected_output() {
 }
 
 #[test]
+fn check_succeeds_for_new_scaffold() {
+    let dir = tempdir().expect("tempdir should be created");
+    let root = dir.path();
+
+    let new_output = run_cli(root, &["new", "my-portfolio"]);
+    assert!(
+        new_output.status.success(),
+        "new failed: {}",
+        String::from_utf8_lossy(&new_output.stderr)
+    );
+
+    let project = root.join("my-portfolio");
+    let check_output = run_cli(&project, &["check"]);
+    assert!(
+        check_output.status.success(),
+        "check failed: {}",
+        String::from_utf8_lossy(&check_output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&check_output.stdout);
+    assert!(stdout.contains("Validated rendered routes:"));
+    assert!(stdout.contains("Validated asset paths:"));
+    assert!(stdout.contains("Check completed: project inputs are valid."));
+    assert!(
+        !project.join("dist").exists(),
+        "check should not write dist output"
+    );
+}
+
+#[test]
+fn check_fails_for_missing_configured_favicon() {
+    let dir = tempdir().expect("tempdir should be created");
+    let root = dir.path();
+
+    let new_output = run_cli(root, &["new", "my-portfolio"]);
+    assert!(
+        new_output.status.success(),
+        "new failed: {}",
+        String::from_utf8_lossy(&new_output.stderr)
+    );
+
+    let project = root.join("my-portfolio");
+    fs::write(
+        project.join("config.toml"),
+        "title = \"My Portfolio\"\nbase_url = \"https://example.com\"\ntheme = \"default\"\npalette = \"default\"\ndescription = \"My personal portfolio site\"\n\n[site]\nfavicon = \"/missing.svg\"\n",
+    )
+    .expect("config should be updated");
+
+    let output = run_cli(&project, &["check"]);
+    assert!(!output.status.success(), "check should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("configured favicon file not found"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+#[test]
 fn new_scaffold_includes_builtin_palettes() {
     let dir = tempdir().expect("tempdir should be created");
     let root = dir.path();


### PR DESCRIPTION
## Summary
- add a `rustipo check` command that validates project inputs without writing build output
- reuse the shared site preparation path for both `build` and `check`
- validate rendered route collisions and asset collisions during the new check flow
- document the new command in the README and CLI reference

## Validation
- cargo fmt --all
- cargo test -q
- cargo clippy --all-targets --all-features -- -D warnings
