### PR TITLE
docs(theme): clarify built-in pagination support

### DIFF
--- a/docs/content-model.md
+++ b/docs/content-model.md
@@ -79,6 +79,7 @@ For example:
   - `content/notes/rust/tips.md` -> `/notes/rust/tips/`
   - `content/notes/index.md` -> `/notes/`
 - blog/project items map to section routes (`/blog/<slug>/`, `/projects/<slug>/`)
+- when blog pagination is needed, listing routes become `/blog/` and `/blog/page/<n>/`
 - `slug` frontmatter overrides filename-derived slug
 - nested directory indexes ignore `slug` for route derivation and keep directory-index routes
 - slugs are normalized to lowercase kebab-case

--- a/docs/implemented-features.md
+++ b/docs/implemented-features.md
@@ -263,6 +263,13 @@
   - `linkable` flag for non-page intermediate segments
 - `previous_post`
 - `next_post`
+- built-in blog listing pagination
+  - `/blog/`
+  - `/blog/page/<n>/`
+  - `current_page`
+  - `total_pages`
+  - `prev_url`
+  - `next_url`
 
 ## Palette System
 

--- a/docs/theme-contract.md
+++ b/docs/theme-contract.md
@@ -156,6 +156,10 @@ Rustipo injects common site variables into template contexts, including:
   - `page_toc`
   - `previous_post`
   - `next_post`
+  - `current_page`
+  - `total_pages`
+  - `prev_url`
+  - `next_url`
 - favicon helpers: `site_favicon`, `site_favicon_svg`, `site_favicon_ico`, `site_apple_touch_icon`
 - style helpers from config:
   - `site_style.content_width`
@@ -242,6 +246,19 @@ Rustipo derives breadcrumb routes from the final rendered route. When an exact p
 section route is known, Rustipo uses its title; otherwise it falls back to a humanized route
 segment label. Intermediate segments without a real page are still included with `linkable =
 false` so themes can show location context without rendering broken links.
+
+Listing templates such as `section.html` also receive pagination helpers when the rendered route is
+part of a paginated listing:
+
+- `current_page`
+- `total_pages`
+- `prev_url`
+- `next_url`
+
+In v1, the built-in paginated listing is the blog section:
+
+- `/blog/`
+- `/blog/page/<n>/`
 
 `previous_post` and `next_post` are only populated for blog post pages.
 They include:

--- a/docs/theme-tera.md
+++ b/docs/theme-tera.md
@@ -194,6 +194,37 @@ Example:
 {% endif %}
 ```
 
+Section-style templates also receive built-in pagination state when Rustipo renders paginated
+listings such as the blog index:
+
+- `current_page`
+- `total_pages`
+- `prev_url`
+- `next_url`
+
+In v1, Rustipo paginates the built-in blog listing using:
+
+- `/blog/` for the first page
+- `/blog/page/<n>/` for later pages
+
+Example:
+
+```html
+{% if total_pages > 1 %}
+<nav aria-label="Pagination">
+  {% if prev_url %}
+  <a href="{{ prev_url }}">Previous</a>
+  {% endif %}
+
+  <span>Page {{ current_page }} of {{ total_pages }}</span>
+
+  {% if next_url %}
+  <a href="{{ next_url }}">Next</a>
+  {% endif %}
+</nav>
+{% endif %}
+```
+
 `breadcrumbs` exposes route-derived breadcrumb items for the current page or section. Themes can
 use `linkable` to avoid rendering dead links for intermediate route segments that do not have a
 real page.


### PR DESCRIPTION
## Summary
- document the built-in paginated blog listing routes
- document pagination context exposed to section templates
- align the roadmap issue with the feature that already ships today

Closes #89