### PR TITLE
fix(ci): use supported intel macos runner

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -58,7 +58,7 @@ jobs:
           - runner: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             binary_name: rustipo
-          - runner: macos-13
+          - runner: macos-15-intel
             target: x86_64-apple-darwin
             binary_name: rustipo
           - runner: macos-14


### PR DESCRIPTION
## Summary
- replace the unsupported Intel macOS runner label in the release workflow
- keep the release binary matrix unchanged otherwise
- preserve automatic asset uploads for future releases

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-please.yml"); puts "yaml-ok"'
