### PR TITLE
feat(docs): publish docs site with github pages

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -1,0 +1,68 @@
+name: Docs Site
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - .github/workflows/docs-site.yml
+      - Cargo.toml
+      - Cargo.lock
+      - assets/themes/**
+      - site/**
+      - src/**
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: docs-site
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build docs site
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: docs-site
+
+      - name: Build Rustipo
+        run: cargo build --release --locked
+
+      - name: Build docs site
+        working-directory: site
+        run: ../target/release/rustipo build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/dist
+
+  deploy:
+    name: Deploy docs site
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ What each part is for:
 
 ## Documentation
 
+- [published docs site](https://fcendesu.github.io/rustipo/)
 - [docs site source](./site)
 - [CLI reference](./docs/cli.md)
 - [Project structure](./docs/project-structure.md)

--- a/site/content/guides/building-the-docs-site.md
+++ b/site/content/guides/building-the-docs-site.md
@@ -44,10 +44,18 @@ From the repository root:
 
 ```bash
 cd site
-../../target/debug/rustipo build
+../target/debug/rustipo build
 ```
 
 In CI, Rustipo also copies `site/` to a temporary directory and runs a full build as an end-to-end check.
+
+## Publishing
+
+The docs site is published from this repository with GitHub Pages.
+
+- pushes to `master` rebuild and deploy the site automatically
+- the published URL is `https://fcendesu.github.io/rustipo/`
+- the workflow lives at `.github/workflows/docs-site.yml`
 
 ## What This Site Should Showcase
 


### PR DESCRIPTION
## Summary
- add a GitHub Pages workflow for the in-repo docs site
- publish the docs site from site/ on pushes to master
- document the live docs URL and fix the local docs-site build command

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docs-site.yml"); puts "yaml-ok"'
- cd site && cargo run --manifest-path ../Cargo.toml -- build
