### PR TITLE
fix(render): honor base_url subpaths in public urls

### DIFF
--- a/assets/themes/atlas/templates/base.html
+++ b/assets/themes/atlas/templates/base.html
@@ -10,7 +10,7 @@
   <body>
     <div class="docs-shell">
       <aside class="docs-sidebar">
-        <a class="docs-brand" href="/">{{ site_title }}</a>
+        <a class="docs-brand" href="{{ site_root }}">{{ site_title }}</a>
         <p class="docs-tagline">{{ site_description }}</p>
         <nav class="docs-nav" aria-label="Primary navigation">
           {% for item in site_nav %}

--- a/assets/themes/atlas/templates/partials/head_assets.html
+++ b/assets/themes/atlas/templates/partials/head_assets.html
@@ -18,8 +18,8 @@
   {{ site_font_faces_css | safe }}
 </style>
 {% endif %}
-<link rel="stylesheet" href="/style.css" />
-<link rel="stylesheet" href="/palette.css" />
+<link rel="stylesheet" href="{{ asset_url(path='style.css') }}" />
+<link rel="stylesheet" href="{{ asset_url(path='palette.css') }}" />
 {% if site_has_custom_css %}
-<link rel="stylesheet" href="/custom.css" />
+<link rel="stylesheet" href="{{ asset_url(path='custom.css') }}" />
 {% endif %}

--- a/assets/themes/journal/templates/base.html
+++ b/assets/themes/journal/templates/base.html
@@ -10,7 +10,7 @@
     <div class="shell">
       <header class="site-header">
         <div>
-          <a class="brand" href="/">{{ site_title }}</a>
+          <a class="brand" href="{{ site_root }}">{{ site_title }}</a>
           <p class="tagline">{{ site_description }}</p>
         </div>
         <nav class="site-nav" aria-label="Main navigation">

--- a/assets/themes/journal/templates/partials/head_assets.html
+++ b/assets/themes/journal/templates/partials/head_assets.html
@@ -18,8 +18,8 @@
   {{ site_font_faces_css | safe }}
 </style>
 {% endif %}
-<link rel="stylesheet" href="/style.css" />
-<link rel="stylesheet" href="/palette.css" />
+<link rel="stylesheet" href="{{ asset_url(path='style.css') }}" />
+<link rel="stylesheet" href="{{ asset_url(path='palette.css') }}" />
 {% if site_has_custom_css %}
-<link rel="stylesheet" href="/custom.css" />
+<link rel="stylesheet" href="{{ asset_url(path='custom.css') }}" />
 {% endif %}

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -31,7 +31,11 @@ fn build_site_with_logging(verbose: bool, publication_mode: PublicationMode) -> 
         "dist",
     )?;
     let rss_items = crate::output::rss::write_rss_feed("dist", &prepared.config, &prepared.pages)?;
-    let search_documents = crate::output::search::write_search_index("dist", &prepared.pages)?;
+    let search_documents = crate::output::search::write_search_index(
+        "dist",
+        &prepared.config.base_url,
+        &prepared.pages,
+    )?;
     let sitemap_urls = crate::output::sitemap::write_sitemap(
         "dist",
         &prepared.config.base_url,

--- a/src/commands/new/scaffold.rs
+++ b/src/commands/new/scaffold.rs
@@ -106,10 +106,10 @@ pub const HEAD_ASSETS_PARTIAL: &str = r#"{% if site_favicon_svg %}<link rel="ico
   {{ site_font_faces_css | safe }}
 </style>
 {% endif %}
-<link rel="stylesheet" href="/style.css" />
-<link rel="stylesheet" href="/palette.css" />
+<link rel="stylesheet" href="{{ asset_url(path='style.css') }}" />
+<link rel="stylesheet" href="{{ asset_url(path='palette.css') }}" />
 {% if site_has_custom_css %}
-<link rel="stylesheet" href="/custom.css" />
+<link rel="stylesheet" href="{{ asset_url(path='custom.css') }}" />
 {% endif %}
 "#;
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -56,6 +56,10 @@ pub struct LayoutOptions {
 }
 
 impl SiteConfig {
+    pub fn public_url_path(&self, path: &str) -> String {
+        crate::url::public_url_path(&self.base_url, path)
+    }
+
     pub fn posts_per_page(&self) -> usize {
         self.site
             .as_ref()
@@ -69,17 +73,17 @@ impl SiteConfig {
         let static_dir = project_root.join("static");
 
         let mut links = FaviconLinks {
-            icon_href: Some("/favicon.ico".to_string()),
-            ico_href: Some("/favicon.ico".to_string()),
+            icon_href: Some(self.public_url_path("/favicon.ico")),
+            ico_href: Some(self.public_url_path("/favicon.ico")),
             svg_href: None,
             apple_touch_icon_href: None,
         };
 
         if static_dir.join("favicon.svg").is_file() {
-            links.svg_href = Some("/favicon.svg".to_string());
+            links.svg_href = Some(self.public_url_path("/favicon.svg"));
         }
         if static_dir.join("apple-touch-icon.png").is_file() {
-            links.apple_touch_icon_href = Some("/apple-touch-icon.png".to_string());
+            links.apple_touch_icon_href = Some(self.public_url_path("/apple-touch-icon.png"));
         }
 
         if let Some(configured) = self
@@ -99,13 +103,13 @@ impl SiteConfig {
                 );
             }
 
-            links.icon_href = Some(href.clone());
+            links.icon_href = Some(self.public_url_path(&href));
             if href.ends_with(".svg") {
-                links.svg_href = Some(href);
+                links.svg_href = Some(self.public_url_path(&href));
             } else if href.ends_with(".ico") {
-                links.ico_href = Some(href);
+                links.ico_href = Some(self.public_url_path(&href));
             } else if href.ends_with("apple-touch-icon.png") {
-                links.apple_touch_icon_href = Some(href);
+                links.apple_touch_icon_href = Some(self.public_url_path(&href));
             }
         }
 
@@ -315,6 +319,15 @@ mod tests {
                 .to_string()
                 .contains("configured favicon file not found")
         );
+    }
+
+    #[test]
+    fn prefixes_public_paths_when_base_url_has_subpath() {
+        let mut config = base_config();
+        config.base_url = "https://example.com/docs/".to_string();
+
+        assert_eq!(config.public_url_path("/guides/"), "/docs/guides/");
+        assert_eq!(config.public_url_path("style.css"), "/docs/style.css");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod palette;
 mod render;
 mod server;
 mod theme;
+mod url;
 
 use anyhow::Result;
 use clap::Parser;

--- a/src/output/search.rs
+++ b/src/output/search.rs
@@ -16,12 +16,19 @@ struct SearchDocument {
     content: String,
 }
 
-pub fn write_search_index(dist_dir: impl AsRef<Path>, pages: &[Page]) -> Result<usize> {
+pub fn write_search_index(
+    dist_dir: impl AsRef<Path>,
+    base_url: &str,
+    pages: &[Page],
+) -> Result<usize> {
     let dist_dir = dist_dir.as_ref();
     fs::create_dir_all(dist_dir)
         .with_context(|| format!("failed to create output directory: {}", dist_dir.display()))?;
 
-    let mut docs = pages.iter().map(to_search_document).collect::<Vec<_>>();
+    let mut docs = pages
+        .iter()
+        .map(|page| to_search_document(page, base_url))
+        .collect::<Vec<_>>();
     docs.sort_by(|a, b| a.route.cmp(&b.route));
 
     let output = dist_dir.join("search-index.json");
@@ -33,9 +40,9 @@ pub fn write_search_index(dist_dir: impl AsRef<Path>, pages: &[Page]) -> Result<
     Ok(docs.len())
 }
 
-fn to_search_document(page: &Page) -> SearchDocument {
+fn to_search_document(page: &Page, base_url: &str) -> SearchDocument {
     SearchDocument {
-        route: page.route.clone(),
+        route: crate::url::public_url_path(base_url, &page.route),
         title: page
             .frontmatter
             .title
@@ -87,7 +94,8 @@ mod tests {
         .expect("post should be written");
 
         let pages = build_pages(&content_dir).expect("pages should build");
-        let count = write_search_index(&dist_dir, &pages).expect("search index should write");
+        let count = write_search_index(&dist_dir, "https://example.com/docs/", &pages)
+            .expect("search index should write");
         assert_eq!(count, 2);
 
         let raw =
@@ -99,7 +107,9 @@ mod tests {
 
         let blog_doc = docs
             .iter()
-            .find(|doc| doc.get("route").and_then(|route| route.as_str()) == Some("/blog/post/"))
+            .find(|doc| {
+                doc.get("route").and_then(|route| route.as_str()) == Some("/docs/blog/post/")
+            })
             .expect("blog route should be present");
         assert_eq!(
             blog_doc.get("title").and_then(|v| v.as_str()),

--- a/src/render/templates/archive.rs
+++ b/src/render/templates/archive.rs
@@ -38,7 +38,7 @@ pub(super) fn render_blog_archive_page(
                 .title
                 .clone()
                 .unwrap_or_else(|| page.slug.clone()),
-            route: page.route.clone(),
+            route: env.config.public_url_path(&page.route),
             summary: page.frontmatter.summary.clone(),
             date: page.frontmatter.date.as_ref().map(ToString::to_string),
         };
@@ -67,8 +67,9 @@ pub(super) fn render_blog_archive_page(
     archive_groups.sort_by(|a, b| b.key.cmp(&a.key));
 
     let route = "/blog/archive/".to_string();
+    let public_route = env.config.public_url_path(&route);
     let mut context = TeraContext::new();
-    context.insert("route", &route);
+    context.insert("route", &public_route);
     context.insert("section_name", "archive");
     context.insert("section_title", "Archive");
     context.insert("items", &all_items);

--- a/src/render/templates/context.rs
+++ b/src/render/templates/context.rs
@@ -80,6 +80,7 @@ pub(super) fn build_shared_template_data(
 
 pub(super) fn insert_page_context(
     context: &mut TeraContext,
+    config: &SiteConfig,
     shared: &SharedTemplateData,
     route: &str,
     page_kind: &str,
@@ -89,18 +90,30 @@ pub(super) fn insert_page_context(
     context.insert("current_section", current_section);
     context.insert(
         "site_nav",
-        &site_nav_for_route(shared, route, current_section),
+        &site_nav_for_route(shared, config, route, current_section),
     );
-    context.insert("site_menus", &site_menus_for_route(shared, route));
-    context.insert("breadcrumbs", &breadcrumbs_for_route(shared, route));
+    context.insert("site_menus", &site_menus_for_route(shared, config, route));
+    context.insert("breadcrumbs", &breadcrumbs_for_route(shared, config, route));
 
     let adjacent = shared
         .adjacent_posts
         .get(route)
         .cloned()
         .unwrap_or_default();
-    context.insert("previous_post", &adjacent.previous_post);
-    context.insert("next_post", &adjacent.next_post);
+    context.insert(
+        "previous_post",
+        &adjacent.previous_post.map(|post| AdjacentPost {
+            route: config.public_url_path(&post.route),
+            ..post
+        }),
+    );
+    context.insert(
+        "next_post",
+        &adjacent.next_post.map(|post| AdjacentPost {
+            route: config.public_url_path(&post.route),
+            ..post
+        }),
+    );
 }
 
 fn build_nav_entries(pages: &[Page]) -> Vec<NavEntry> {
@@ -239,11 +252,12 @@ fn breadcrumb_title_for_page(page: &Page) -> String {
 
 fn site_nav_for_route(
     shared: &SharedTemplateData,
+    config: &SiteConfig,
     route: &str,
     current_section: &str,
 ) -> Vec<NavItem> {
     if let Some(main_menu) = shared.configured_menus.get("main") {
-        return configured_menu_for_route(main_menu, route);
+        return configured_menu_for_route(main_menu, config, route);
     }
 
     shared
@@ -251,7 +265,7 @@ fn site_nav_for_route(
         .iter()
         .map(|entry| NavItem {
             title: entry.title.clone(),
-            route: entry.route.clone(),
+            route: config.public_url_path(&entry.route),
             active: nav_entry_is_active(entry, route, current_section),
         })
         .collect()
@@ -259,16 +273,26 @@ fn site_nav_for_route(
 
 fn site_menus_for_route(
     shared: &SharedTemplateData,
+    config: &SiteConfig,
     route: &str,
 ) -> BTreeMap<String, Vec<NavItem>> {
     shared
         .configured_menus
         .iter()
-        .map(|(name, entries)| (name.clone(), configured_menu_for_route(entries, route)))
+        .map(|(name, entries)| {
+            (
+                name.clone(),
+                configured_menu_for_route(entries, config, route),
+            )
+        })
         .collect()
 }
 
-fn breadcrumbs_for_route(shared: &SharedTemplateData, route: &str) -> Vec<BreadcrumbItem> {
+fn breadcrumbs_for_route(
+    shared: &SharedTemplateData,
+    config: &SiteConfig,
+    route: &str,
+) -> Vec<BreadcrumbItem> {
     let Some(segments) = breadcrumb_segments(route) else {
         return Vec::new();
     };
@@ -280,7 +304,7 @@ fn breadcrumbs_for_route(shared: &SharedTemplateData, route: &str) -> Vec<Breadc
                 .get(route)
                 .cloned()
                 .unwrap_or_else(|| "Home".to_string()),
-            route: route.to_string(),
+            route: config.public_url_path(route),
             active: true,
             linkable: shared.linkable_breadcrumb_routes.contains(route),
         }];
@@ -291,7 +315,7 @@ fn breadcrumbs_for_route(shared: &SharedTemplateData, route: &str) -> Vec<Breadc
     if let Some(home_title) = shared.breadcrumb_titles.get("/") {
         items.push(BreadcrumbItem {
             title: home_title.clone(),
-            route: "/".to_string(),
+            route: config.public_url_path("/"),
             active: false,
             linkable: shared.linkable_breadcrumb_routes.contains("/"),
         });
@@ -305,7 +329,7 @@ fn breadcrumbs_for_route(shared: &SharedTemplateData, route: &str) -> Vec<Breadc
                 .get(&crumb_route)
                 .cloned()
                 .unwrap_or_else(|| titleize_segment(segment)),
-            route: crumb_route.clone(),
+            route: config.public_url_path(&crumb_route),
             active: crumb_route == route,
             linkable: shared.linkable_breadcrumb_routes.contains(&crumb_route),
         });
@@ -329,12 +353,16 @@ fn breadcrumb_segments(route: &str) -> Option<Vec<String>> {
     Some(segments)
 }
 
-fn configured_menu_for_route(entries: &[ConfiguredMenuEntry], route: &str) -> Vec<NavItem> {
+fn configured_menu_for_route(
+    entries: &[ConfiguredMenuEntry],
+    config: &SiteConfig,
+    route: &str,
+) -> Vec<NavItem> {
     entries
         .iter()
         .map(|entry| NavItem {
             title: entry.title.clone(),
-            route: entry.route.clone(),
+            route: config.public_url_path(&entry.route),
             active: configured_menu_entry_is_active(entry, route),
         })
         .collect()

--- a/src/render/templates/helpers.rs
+++ b/src/render/templates/helpers.rs
@@ -15,8 +15,18 @@ pub(super) fn register(tera: &mut Tera, config: &SiteConfig) {
             base_url: config.base_url.clone(),
         },
     );
-    tera.register_function("asset_url", AssetUrlFunction);
-    tera.register_function("tag_url", TagUrlFunction);
+    tera.register_function(
+        "asset_url",
+        AssetUrlFunction {
+            base_url: config.base_url.clone(),
+        },
+    );
+    tera.register_function(
+        "tag_url",
+        TagUrlFunction {
+            base_url: config.base_url.clone(),
+        },
+    );
 }
 
 struct SlugifyFilter;
@@ -39,8 +49,12 @@ struct AbsUrlFunction {
 }
 
 struct FormatDateFilter;
-struct AssetUrlFunction;
-struct TagUrlFunction;
+struct AssetUrlFunction {
+    base_url: String,
+}
+struct TagUrlFunction {
+    base_url: String,
+}
 
 impl Function for AbsUrlFunction {
     fn call(&self, args: &HashMap<String, Value>) -> TeraResult<Value> {
@@ -92,7 +106,10 @@ impl Function for AssetUrlFunction {
             .and_then(Value::as_str)
             .ok_or_else(|| TeraError::msg("asset_url requires a string 'path' argument"))?;
 
-        Ok(Value::String(normalize_url_path(path)))
+        Ok(Value::String(crate::url::public_url_path(
+            &self.base_url,
+            path,
+        )))
     }
 }
 
@@ -109,19 +126,10 @@ impl Function for TagUrlFunction {
             ));
         }
 
-        Ok(Value::String(format!("/tags/{slug}/")))
-    }
-}
-
-fn normalize_url_path(path: &str) -> String {
-    if path.starts_with("http://") || path.starts_with("https://") {
-        return path.to_string();
-    }
-
-    if path.starts_with('/') {
-        path.to_string()
-    } else {
-        format!("/{path}")
+        Ok(Value::String(crate::url::public_url_path(
+            &self.base_url,
+            &format!("/tags/{slug}/"),
+        )))
     }
 }
 
@@ -166,7 +174,9 @@ mod tests {
 
     #[test]
     fn normalizes_asset_urls() {
-        let function = AssetUrlFunction;
+        let function = AssetUrlFunction {
+            base_url: "https://example.com/docs/".to_string(),
+        };
         let mut args = HashMap::new();
         args.insert(
             "path".to_string(),
@@ -174,16 +184,18 @@ mod tests {
         );
 
         let value = function.call(&args).expect("asset url should render");
-        assert_eq!(value, Value::String("/img/logo.svg".to_string()));
+        assert_eq!(value, Value::String("/docs/img/logo.svg".to_string()));
     }
 
     #[test]
     fn builds_tag_urls() {
-        let function = TagUrlFunction;
+        let function = TagUrlFunction {
+            base_url: "https://example.com/docs/".to_string(),
+        };
         let mut args = HashMap::new();
         args.insert("name".to_string(), Value::String("Site Gen".to_string()));
 
         let value = function.call(&args).expect("tag url should render");
-        assert_eq!(value, Value::String("/tags/site-gen/".to_string()));
+        assert_eq!(value, Value::String("/docs/tags/site-gen/".to_string()));
     }
 }

--- a/src/render/templates/mod.rs
+++ b/src/render/templates/mod.rs
@@ -91,6 +91,7 @@ fn insert_common_site_context(
 ) {
     context.insert("site_title", &config.title);
     context.insert("site_description", &config.description);
+    context.insert("site_root", &config.public_url_path("/"));
     context.insert("site_favicon", &render_context.site.favicon_links.icon_href);
     context.insert(
         "site_favicon_svg",
@@ -116,11 +117,63 @@ fn insert_common_site_context(
     );
     context::insert_page_context(
         context,
+        config,
         render_context.shared,
         render_context.route,
         render_context.page_kind,
         render_context.current_section,
     );
+}
+
+pub(super) fn rewrite_public_html_urls(html: &str, config: &SiteConfig) -> String {
+    let base_path = crate::url::base_path(&config.base_url);
+    if base_path == "/" {
+        return html.to_string();
+    }
+
+    let mut rewritten = html.to_string();
+    for attr in ["href", "src", "poster", "action"] {
+        rewritten = rewrite_attr_urls(&rewritten, attr, '"', &base_path);
+        rewritten = rewrite_attr_urls(&rewritten, attr, '\'', &base_path);
+    }
+
+    rewritten
+}
+
+fn rewrite_attr_urls(html: &str, attr: &str, quote: char, base_path: &str) -> String {
+    let needle = format!("{attr}={quote}/");
+    let prefix = base_path.trim_start_matches('/');
+    if prefix.is_empty() {
+        return html.to_string();
+    }
+
+    let mut output = String::with_capacity(html.len() + 32);
+    let mut remaining = html;
+
+    while let Some(index) = remaining.find(&needle) {
+        let (before, rest) = remaining.split_at(index);
+        output.push_str(before);
+        output.push_str(&needle);
+
+        let value = &rest[needle.len()..];
+        if !already_prefixed(value, prefix, quote) {
+            output.push_str(prefix);
+            output.push('/');
+        }
+
+        remaining = value;
+    }
+
+    output.push_str(remaining);
+    output
+}
+
+fn already_prefixed(value: &str, prefix: &str, quote: char) -> bool {
+    let Some(rest) = value.strip_prefix(prefix) else {
+        return false;
+    };
+
+    rest.starts_with('/') || rest.starts_with(quote)
 }
 
 fn load_theme_templates(theme: &Theme, config: &SiteConfig) -> Result<Tera> {

--- a/src/render/templates/not_found.rs
+++ b/src/render/templates/not_found.rs
@@ -34,9 +34,11 @@ pub(super) fn render_not_found_page(tera: &Tera, env: &RenderEnvironment<'_>) ->
     };
 
     let mut context = TeraContext::new();
-    context.insert("route", NOT_FOUND_ROUTE);
+    let public_route = env.config.public_url_path(NOT_FOUND_ROUTE);
+    let content_html = super::rewrite_public_html_urls(NOT_FOUND_CONTENT_HTML, env.config);
+    context.insert("route", &public_route);
     context.insert("slug", "404");
-    context.insert("content_html", NOT_FOUND_CONTENT_HTML);
+    context.insert("content_html", &content_html);
     context.insert("frontmatter", &frontmatter);
     context.insert("page_summary", &frontmatter.summary);
     context.insert(
@@ -66,13 +68,13 @@ pub(super) fn render_not_found_page(tera: &Tera, env: &RenderEnvironment<'_>) ->
         &vec![
             BreadcrumbItem {
                 title: "Home".to_string(),
-                route: "/".to_string(),
+                route: env.config.public_url_path("/"),
                 active: false,
                 linkable: true,
             },
             BreadcrumbItem {
                 title: "Page not found".to_string(),
-                route: NOT_FOUND_ROUTE.to_string(),
+                route: public_route,
                 active: true,
                 linkable: false,
             },

--- a/src/render/templates/page.rs
+++ b/src/render/templates/page.rs
@@ -35,10 +35,12 @@ pub(super) fn render_content_pages(
     for page in pages {
         let template = template_for_kind(page.kind);
         let mut context = TeraContext::new();
+        let public_route = env.config.public_url_path(&page.route);
+        let content_html = super::rewrite_public_html_urls(&page.html, env.config);
 
-        context.insert("route", &page.route);
+        context.insert("route", &public_route);
         context.insert("slug", &page.slug);
-        context.insert("content_html", &page.html);
+        context.insert("content_html", &content_html);
         context.insert("frontmatter", &page.frontmatter);
         context.insert("page_summary", &page.frontmatter.summary);
         context.insert(

--- a/src/render/templates/section.rs
+++ b/src/render/templates/section.rs
@@ -40,7 +40,7 @@ fn render_blog_section_pages(
                 .title
                 .clone()
                 .unwrap_or_else(|| page.slug.clone()),
-            route: page.route.clone(),
+            route: env.config.public_url_path(&page.route),
             summary: page.frontmatter.summary.clone(),
             date: page.frontmatter.date.as_ref().map(ToString::to_string),
         })
@@ -68,18 +68,24 @@ fn render_blog_section_pages(
         let prev_url = if page_number <= 1 {
             None
         } else if page_number == 2 {
-            Some("/blog/".to_string())
+            Some(env.config.public_url_path("/blog/"))
         } else {
-            Some(format!("/blog/page/{}/", page_number - 1))
+            Some(
+                env.config
+                    .public_url_path(&format!("/blog/page/{}/", page_number - 1)),
+            )
         };
         let next_url = if page_number < total_pages {
-            Some(format!("/blog/page/{}/", page_number + 1))
+            Some(
+                env.config
+                    .public_url_path(&format!("/blog/page/{}/", page_number + 1)),
+            )
         } else {
             None
         };
 
         let mut context = TeraContext::new();
-        context.insert("route", &route);
+        context.insert("route", &env.config.public_url_path(&route));
         context.insert("section_name", "blog");
         context.insert("section_title", "Blog");
         context.insert("items", &paged_items);
@@ -124,14 +130,14 @@ fn render_projects_section_page(
                 .title
                 .clone()
                 .unwrap_or_else(|| page.slug.clone()),
-            route: page.route.clone(),
+            route: env.config.public_url_path(&page.route),
             summary: page.frontmatter.summary.clone(),
             date: page.frontmatter.date.as_ref().map(ToString::to_string),
         })
         .collect::<Vec<_>>();
 
     let mut context = TeraContext::new();
-    context.insert("route", "/projects/");
+    context.insert("route", &env.config.public_url_path("/projects/"));
     context.insert("section_name", "projects");
     context.insert("section_title", "Projects");
     context.insert("items", &items);

--- a/src/render/templates/tags.rs
+++ b/src/render/templates/tags.rs
@@ -34,7 +34,7 @@ pub(super) fn render_tag_pages(
             .unwrap_or_else(|| page.slug.clone());
         let item = SectionItem {
             title,
-            route: page.route.clone(),
+            route: env.config.public_url_path(&page.route),
             summary: page.frontmatter.summary.clone(),
             date: page.frontmatter.date.as_ref().map(ToString::to_string),
         };
@@ -57,7 +57,7 @@ pub(super) fn render_tag_pages(
     for (tag_slug, items) in tags {
         let route = format!("/tags/{tag_slug}/");
         let mut context = TeraContext::new();
-        context.insert("route", &route);
+        context.insert("route", &env.config.public_url_path(&route));
         context.insert("section_name", "tags");
         context.insert("section_title", &format!("Tag: {tag_slug}"));
         context.insert("items", &items);

--- a/src/render/templates/tests.rs
+++ b/src/render/templates/tests.rs
@@ -1325,3 +1325,95 @@ fn prefers_dedicated_not_found_template_when_present() {
     assert!(html.contains("Custom 404 for My Site"));
     assert!(!html.contains("Return home"));
 }
+
+#[test]
+fn prefixes_rendered_public_urls_when_base_url_has_subpath() {
+    let dir = tempdir().expect("tempdir should be created");
+    let project_root = dir.path();
+
+    fs::create_dir_all(project_root.join("content/guides")).expect("content dir should be created");
+    fs::write(
+        project_root.join("content/index.md"),
+        "# Welcome\n\n[Guide](/guides/start/)\n\n![Logo](/img/logo.svg)",
+    )
+    .expect("index should be written");
+    fs::write(project_root.join("content/guides/start.md"), "# Start")
+        .expect("guide page should be written");
+
+    let theme_root = project_root.join("themes/default");
+    fs::create_dir_all(theme_root.join("templates")).expect("templates should be created");
+    fs::create_dir_all(theme_root.join("static")).expect("static should be created");
+
+    fs::write(
+        theme_root.join("templates/base.html"),
+        "<html><head><link rel=\"stylesheet\" href=\"{{ asset_url(path='style.css') }}\"></head><body><a class=\"home\" href=\"{{ site_root }}\">Home</a>{% block body %}{% endblock body %}</body></html>",
+    )
+    .expect("base template should be written");
+    for template in [
+        "index.html",
+        "page.html",
+        "post.html",
+        "project.html",
+        "section.html",
+    ] {
+        fs::write(
+            theme_root.join("templates").join(template),
+            "{% extends \"base.html\" %}{% block body %}<article>{{ content_html | safe }}</article>{% endblock body %}",
+        )
+        .expect("template should be written");
+    }
+    fs::write(
+        theme_root.join("theme.toml"),
+        "name = \"default\"\nversion = \"0.1.0\"\nauthor = \"Rustipo\"\ndescription = \"Default\"\n",
+    )
+    .expect("theme metadata should be written");
+
+    let config = SiteConfig {
+        title: "Docs".to_string(),
+        base_url: "https://example.com/rustipo/".to_string(),
+        theme: "default".to_string(),
+        palette: None,
+        menus: None,
+        description: "A site".to_string(),
+        author: None,
+        site: None,
+    };
+
+    let pages = build_pages(project_root.join("content")).expect("pages should build");
+    let theme = load_active_theme(project_root, "default").expect("theme should load");
+    let favicon_links = config
+        .resolve_favicon_links(project_root)
+        .expect("favicon links should resolve");
+    let site_style = config.style_options();
+    let site_has_custom_css = config.has_custom_css(project_root);
+    let palette =
+        load_palette(project_root, config.selected_palette()).expect("palette should load");
+
+    let rendered = render_pages(
+        &theme,
+        &config,
+        &pages,
+        &SiteRenderContext {
+            favicon_links: &favicon_links,
+            site_style: &site_style,
+            site_has_custom_css,
+            site_font_faces_css: None,
+            palette: &palette,
+        },
+    )
+    .expect("pages should render");
+
+    let index = rendered
+        .iter()
+        .find(|page| page.route == "/")
+        .expect("index page should render");
+
+    assert!(index.html.contains("href=\"&#x2F;rustipo&#x2F;style.css\""));
+    assert!(
+        index
+            .html
+            .contains("class=\"home\" href=\"&#x2F;rustipo&#x2F;\"")
+    );
+    assert!(index.html.contains("href=\"/rustipo/guides/start/\""));
+    assert!(index.html.contains("src=\"/rustipo/img/logo.svg\""));
+}

--- a/src/url.rs
+++ b/src/url.rs
@@ -1,0 +1,99 @@
+pub fn base_path(base_url: &str) -> String {
+    let without_scheme = base_url
+        .split_once("://")
+        .map(|(_, rest)| rest)
+        .unwrap_or(base_url);
+
+    let path = without_scheme
+        .find('/')
+        .map(|index| &without_scheme[index..])
+        .unwrap_or("/");
+    let path = path
+        .split(['?', '#'])
+        .next()
+        .unwrap_or(path)
+        .trim_matches('/');
+
+    if path.is_empty() {
+        "/".to_string()
+    } else {
+        format!("/{path}")
+    }
+}
+
+pub fn public_url_path(base_url: &str, path: &str) -> String {
+    if path.is_empty() || is_external_like(path) {
+        return path.to_string();
+    }
+
+    let normalized = if path.starts_with('/') {
+        path.to_string()
+    } else {
+        format!("/{path}")
+    };
+
+    let base = base_path(base_url);
+    if base == "/" {
+        return normalized;
+    }
+
+    if normalized == base || normalized.starts_with(&format!("{base}/")) {
+        return normalized;
+    }
+
+    format!("{base}{normalized}")
+}
+
+fn is_external_like(path: &str) -> bool {
+    path.starts_with("http://")
+        || path.starts_with("https://")
+        || path.starts_with("mailto:")
+        || path.starts_with("tel:")
+        || path.starts_with("data:")
+        || path.starts_with("//")
+        || path.starts_with('#')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{base_path, public_url_path};
+
+    #[test]
+    fn extracts_base_path_from_url() {
+        assert_eq!(base_path("https://example.com"), "/");
+        assert_eq!(base_path("https://example.com/"), "/");
+        assert_eq!(base_path("https://example.com/docs/"), "/docs");
+        assert_eq!(
+            base_path("https://example.com/docs/reference"),
+            "/docs/reference"
+        );
+    }
+
+    #[test]
+    fn prefixes_public_paths_with_base_path() {
+        assert_eq!(
+            public_url_path("https://example.com/docs/", "/guides/"),
+            "/docs/guides/"
+        );
+        assert_eq!(
+            public_url_path("https://example.com/docs/", "style.css"),
+            "/docs/style.css"
+        );
+        assert_eq!(
+            public_url_path("https://example.com/docs/", "/docs/guides/"),
+            "/docs/guides/"
+        );
+    }
+
+    #[test]
+    fn preserves_external_like_paths() {
+        assert_eq!(
+            public_url_path("https://example.com/docs/", "https://github.com"),
+            "https://github.com"
+        );
+        assert_eq!(
+            public_url_path("https://example.com/docs/", "#intro"),
+            "#intro"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- prefix public asset, navigation, breadcrumb, and rendered content URLs with the configured base_url path
- expose a shared URL helper for template functions, favicon links, and search routes
- cover GitHub Pages-style subpath rendering with regression tests and verify the in-repo docs site build

## Testing
- cargo fmt --all
- cargo test -q
- cargo clippy --all-targets --all-features -- -D warnings
- cd site && ../target/debug/rustipo build