### PR TITLE
chore(ci): prepare workflows for node24 actions

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -13,6 +13,9 @@ on:
       - src/**
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
   pages: write
@@ -29,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure Pages
         uses: actions/configure-pages@v5
@@ -50,7 +53,7 @@ jobs:
         run: ../target/release/rustipo build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: site/dist
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Sync GitHub release notes body
         if: ${{ steps.release.outputs.release_created == 'true' && steps.release.outputs.tag_name != '' && steps.release.outputs.body != '' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           RELEASE_TAG: ${{ steps.release.outputs.tag_name }}
           RELEASE_BODY: ${{ steps.release.outputs.body }}
@@ -69,7 +69,7 @@ jobs:
             binary_name: rustipo.exe
     steps:
       - name: Check out release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
 
@@ -118,7 +118,7 @@ jobs:
           Compress-Archive -Path "$archiveStem/*" -DestinationPath "$archiveStem.zip"
 
       - name: Upload release archive artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-binary-${{ matrix.target }}
           path: ${{ github.workspace }}/${{ needs.release-please.outputs.tag_name }}-${{ matrix.target }}.*
@@ -133,7 +133,7 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created == 'true' && needs.release-please.outputs.tag_name != '' }}
     steps:
       - name: Download packaged release archives
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: release-binary-*
           path: release-assets

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,6 +21,7 @@ Current shipped post-MVP capabilities:
 - completed `v0.8.0` core authoring release
 - completed `v0.9.0` publishing and site structure release
 - completed `v0.10.0` product identity and examples release
+- completed `v0.11.0` distribution and docs release
 - flagship example sites for blog and docs-style use cases
 - built-in `atlas` and `journal` layout themes
 - generated publishing/search artifacts during build:
@@ -59,13 +60,15 @@ For historical post-MVP batch planning, see:
   - broader Markdown-first site-generator positioning
   - flagship `journal` and `knowledge-base` examples
   - built-in `atlas` and `journal` layout themes
-
-## Upcoming milestones
-
 - `v0.11.0`: distribution and docs
   - docs site built with Rustipo
   - prebuilt binaries
   - Homebrew distribution
+
+## Upcoming milestones
+
+- `v0.12.0`: maintenance and workflow compatibility
+  - audit GitHub Actions workflows for Node 24 compatibility
 
 ## Milestone 1: Foundation
 


### PR DESCRIPTION
## Summary
- opt the docs-site workflow into the Node 24 JavaScript action runtime
- bump audited workflow actions to current major versions where upstream releases are available
- add `v0.12.0` Node 24 workflow compatibility work to the public roadmap

## Testing
- ruby -e 'require "yaml"; [".github/workflows/docs-site.yml", ".github/workflows/release-please.yml"].each { |f| YAML.load_file(f); puts "OK #{f}" }'
- cargo test -q
