### PR TITLE
chore(ci): opt jobs into node24 action runtime

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -29,6 +29,8 @@ jobs:
   build:
     name: Build docs site
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
     steps:
       - name: Checkout
@@ -61,6 +63,8 @@ jobs:
     name: Deploy docs site
     runs-on: ubuntu-latest
     needs: build
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -51,6 +53,8 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' && needs.release-please.outputs.tag_name != '' }}
     runs-on: ${{ matrix.runner }}
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     strategy:
       fail-fast: false
       matrix:
@@ -131,6 +135,8 @@ jobs:
       - release-please
       - release-binaries
     if: ${{ needs.release-please.outputs.release_created == 'true' && needs.release-please.outputs.tag_name != '' }}
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - name: Download packaged release archives
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary
- move the Node 24 JavaScript action opt-in to job scope in the docs-site workflow
- move the same opt-in to each release workflow job so the runner sees it on every job

## Testing
- ruby -e 'require "yaml"; [".github/workflows/docs-site.yml", ".github/workflows/release-please.yml"].each { |f| YAML.load_file(f); puts "OK #{f}" }'
