### PR TITLE
docs(site): fill section landing pages

### DIFF
--- a/site/content/examples/index.md
+++ b/site/content/examples/index.md
@@ -2,3 +2,23 @@
 title: Examples
 summary: Compare the bundled example sites and the built-in themes they exercise.
 ---
+
+Rustipo ships with example sites so you can compare different site shapes without building each one from scratch in your head.
+
+## In this section
+
+- [Basic portfolio](/examples/basic-portfolio/)
+- [Journal](/examples/journal/)
+- [Knowledge base](/examples/knowledge-base/)
+
+## What each example highlights
+
+- [Basic portfolio](/examples/basic-portfolio/): the original starter shape for a small personal site
+- [Journal](/examples/journal/): a writing-focused layout that uses the built-in `journal` theme
+- [Knowledge base](/examples/knowledge-base/): a docs-and-notes layout that uses the built-in `atlas` theme
+
+## How to use the examples
+
+- compare their content structure
+- inspect their `config.toml` files
+- build them locally to see how theme and palette choices affect the final output

--- a/site/content/guides/index.md
+++ b/site/content/guides/index.md
@@ -2,3 +2,21 @@
 title: Guides
 summary: Step-by-step workflows for getting started and working on the docs site itself.
 ---
+
+Rustipo's guides are the best place to start when you want a practical path through the product instead of a reference dump.
+
+## In this section
+
+- [Getting started](/guides/getting-started/)
+- [Building the docs site](/guides/building-the-docs-site/)
+
+## Suggested order
+
+1. Start with [Getting started](/guides/getting-started/) to create and preview a site locally.
+2. Continue to [Building the docs site](/guides/building-the-docs-site/) if you want to understand how Rustipo's own documentation project is structured.
+
+## What guides focus on
+
+- setup and first build workflows
+- the relationship between content, themes, and palettes
+- how the in-repo docs project is organized and published

--- a/site/content/reference/index.md
+++ b/site/content/reference/index.md
@@ -2,3 +2,22 @@
 title: Reference
 summary: Command, content, and theming reference for Rustipo.
 ---
+
+The reference section is for the parts of Rustipo you may want to revisit while building a real site: commands, content conventions, and the theme contract.
+
+## In this section
+
+- [CLI reference](/reference/cli/)
+- [Content model](/reference/content-model/)
+- [Themes and palettes](/reference/themes-and-palettes/)
+
+## Use this section when you need
+
+- exact command behavior and install workflows
+- the Markdown and routing rules Rustipo follows
+- the template context and palette model available to theme authors
+
+## Good companion pages
+
+- [Guides](/guides/) for step-by-step workflows
+- [Examples](/examples/) to see finished site shapes


### PR DESCRIPTION
## Summary
- add real landing-page content to the Guides, Reference, and Examples docs sections
- link each section to its child pages so the section indexes are useful instead of blank

## Testing
- cargo test -q
- cd site && ../target/debug/rustipo build
