### PR TITLE
fix(theme): remove atlas breadcrumb header

### DIFF
--- a/assets/themes/atlas/static/style.css
+++ b/assets/themes/atlas/static/style.css
@@ -48,7 +48,6 @@ body {
 
 .docs-tagline,
 .docs-meta,
-.breadcrumbs,
 .docs-toc,
 .section-list p,
 .doc-meta {
@@ -67,7 +66,6 @@ body {
 
 .docs-nav a,
 .docs-meta a,
-.breadcrumbs a,
 .doc-card a,
 .docs-toc a,
 .pagination a {
@@ -96,21 +94,6 @@ body {
   width: 100%;
   max-width: calc(var(--rustipo-content-width) + 4rem);
   padding: 1.5rem 1.5rem 3rem;
-}
-
-.docs-header {
-  margin-bottom: 1rem;
-}
-
-.breadcrumbs {
-  display: flex;
-  gap: 0.6rem;
-  flex-wrap: wrap;
-  font-size: 0.93rem;
-}
-
-.breadcrumbs span[aria-current="page"] {
-  color: var(--rustipo-text);
 }
 
 .docs-content-grid {

--- a/assets/themes/atlas/templates/base.html
+++ b/assets/themes/atlas/templates/base.html
@@ -26,19 +26,6 @@
         {% endif %}
       </aside>
       <div class="docs-main">
-        <header class="docs-header">
-          {% if breadcrumbs %}
-          <nav class="breadcrumbs" aria-label="Breadcrumbs">
-            {% for item in breadcrumbs %}
-              {% if item.linkable and not item.active %}
-              <a href="{{ item.route }}">{{ item.title }}</a>
-              {% else %}
-              <span {% if item.active %}aria-current="page"{% endif %}>{{ item.title }}</span>
-              {% endif %}
-            {% endfor %}
-          </nav>
-          {% endif %}
-        </header>
         <div class="docs-content-grid">
           <main class="docs-content">
             {% block body %}{% endblock body %}


### PR DESCRIPTION
## Summary
- remove the top breadcrumb strip from the built-in atlas theme
- rely on the left sidebar and page TOC instead of duplicating section labels above the content

## Testing
- cargo test -q
- cd site && ../target/debug/rustipo build
