### PR TITLE
fix(theme): make atlas sidebar toggleable and bust asset cache

### DIFF
--- a/assets/themes/atlas/static/style.css
+++ b/assets/themes/atlas/static/style.css
@@ -27,6 +27,10 @@ body {
   min-height: 100vh;
 }
 
+body.docs-sidebar-collapsed .docs-shell {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .docs-sidebar {
   position: sticky;
   top: 0;
@@ -35,6 +39,10 @@ body {
   padding: 1.6rem 1.15rem;
   border-right: 1px solid var(--rustipo-surface-1, var(--rustipo-border));
   background: color-mix(in srgb, var(--rustipo-mantle) 82%, var(--rustipo-base) 18%);
+}
+
+body.docs-sidebar-collapsed .docs-sidebar {
+  display: none;
 }
 
 .docs-sidebar-head {
@@ -91,7 +99,7 @@ body {
 
 .docs-menu-toggle,
 .docs-sidebar-close {
-  display: none;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
@@ -127,6 +135,9 @@ body {
   right: 1rem;
   bottom: 1rem;
   z-index: 45;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   padding: 0.7rem 0.9rem;
   cursor: pointer;
   opacity: 0;
@@ -173,6 +184,11 @@ body {
   width: 100%;
   max-width: calc(var(--rustipo-content-width) + 4rem);
   padding: 1.5rem 1.5rem 3rem;
+}
+
+body.docs-sidebar-collapsed .docs-main {
+  max-width: min(1600px, calc(var(--rustipo-content-width) + 22rem));
+  padding-left: 5.2rem;
 }
 
 .docs-content-grid {
@@ -350,13 +366,12 @@ body {
 }
 
 @media (max-width: 860px) {
-  .docs-menu-toggle,
-  .docs-sidebar-close {
-    display: inline-flex;
-  }
-
   .docs-shell {
     grid-template-columns: 1fr;
+  }
+
+  body.docs-sidebar-collapsed .docs-sidebar {
+    display: block;
   }
 
   .docs-sidebar {
@@ -376,6 +391,10 @@ body {
     transform: translateX(0);
   }
 
+  body.docs-sidebar-open {
+    overflow: hidden;
+  }
+
   .docs-overlay {
     display: block;
   }
@@ -386,6 +405,10 @@ body {
   }
 
   .docs-main {
+    padding: 4.6rem 1rem 2rem;
+  }
+
+  body.docs-sidebar-collapsed .docs-main {
     padding: 4.6rem 1rem 2rem;
   }
 

--- a/assets/themes/atlas/templates/base.html
+++ b/assets/themes/atlas/templates/base.html
@@ -79,40 +79,51 @@
 
         const mobileQuery = window.matchMedia("(max-width: 860px)");
 
-        const setDrawerOpen = (open) => {
-          document.body.classList.toggle("docs-sidebar-open", open);
+        const isMobile = () => mobileQuery.matches;
+
+        const isSidebarOpen = () => {
+          if (isMobile()) {
+            return document.body.classList.contains("docs-sidebar-open");
+          }
+
+          return !document.body.classList.contains("docs-sidebar-collapsed");
+        };
+
+        const setSidebarOpen = (open) => {
+          if (isMobile()) {
+            document.body.classList.toggle("docs-sidebar-open", open);
+            document.body.classList.remove("docs-sidebar-collapsed");
+            overlay.hidden = !open;
+          } else {
+            document.body.classList.remove("docs-sidebar-open");
+            document.body.classList.toggle("docs-sidebar-collapsed", !open);
+            overlay.hidden = true;
+          }
+
           menuToggle.setAttribute("aria-expanded", String(open));
-          overlay.hidden = !open;
         };
 
         const syncDrawerMode = () => {
-          setDrawerOpen(false);
-          if (!mobileQuery.matches) {
-            overlay.hidden = true;
-          }
+          setSidebarOpen(!isMobile());
         };
 
         menuToggle.addEventListener("click", () => {
-          if (!mobileQuery.matches) {
-            return;
-          }
-
-          setDrawerOpen(!document.body.classList.contains("docs-sidebar-open"));
+          setSidebarOpen(!isSidebarOpen());
         });
 
-        sidebarClose.addEventListener("click", () => setDrawerOpen(false));
-        overlay.addEventListener("click", () => setDrawerOpen(false));
+        sidebarClose.addEventListener("click", () => setSidebarOpen(false));
+        overlay.addEventListener("click", () => setSidebarOpen(false));
 
         document.addEventListener("keydown", (event) => {
-          if (event.key === "Escape") {
-            setDrawerOpen(false);
+          if (event.key === "Escape" && isSidebarOpen()) {
+            setSidebarOpen(false);
           }
         });
 
         sidebar.querySelectorAll("a").forEach((link) => {
           link.addEventListener("click", () => {
-            if (mobileQuery.matches) {
-              setDrawerOpen(false);
+            if (isMobile()) {
+              setSidebarOpen(false);
             }
           });
         });

--- a/assets/themes/atlas/templates/partials/head_assets.html
+++ b/assets/themes/atlas/templates/partials/head_assets.html
@@ -1,7 +1,7 @@
-{% if site_favicon_svg %}<link rel="icon" href="{{ site_favicon_svg }}" type="image/svg+xml" />{% endif %}
-{% if site_favicon_ico %}<link rel="icon" href="{{ site_favicon_ico }}" sizes="any" />{% endif %}
-{% if site_apple_touch_icon %}<link rel="apple-touch-icon" href="{{ site_apple_touch_icon }}" />{% endif %}
-{% if site_favicon and not site_favicon_svg and not site_favicon_ico %}<link rel="icon" href="{{ site_favicon }}" />{% endif %}
+{% if site_favicon_svg %}<link rel="icon" href="{{ site_favicon_svg }}?v={{ site_asset_version }}" type="image/svg+xml" />{% endif %}
+{% if site_favicon_ico %}<link rel="icon" href="{{ site_favicon_ico }}?v={{ site_asset_version }}" sizes="any" />{% endif %}
+{% if site_apple_touch_icon %}<link rel="apple-touch-icon" href="{{ site_apple_touch_icon }}?v={{ site_asset_version }}" />{% endif %}
+{% if site_favicon and not site_favicon_svg and not site_favicon_ico %}<link rel="icon" href="{{ site_favicon }}?v={{ site_asset_version }}" />{% endif %}
 <style>
   :root {
     --rustipo-content-width: {{ site_style.content_width | default(value="1280px") }};
@@ -18,8 +18,8 @@
   {{ site_font_faces_css | safe }}
 </style>
 {% endif %}
-<link rel="stylesheet" href="{{ asset_url(path='style.css') }}" />
-<link rel="stylesheet" href="{{ asset_url(path='palette.css') }}" />
+<link rel="stylesheet" href="{{ asset_url(path='style.css') }}?v={{ site_asset_version }}" />
+<link rel="stylesheet" href="{{ asset_url(path='palette.css') }}?v={{ site_asset_version }}" />
 {% if site_has_custom_css %}
-<link rel="stylesheet" href="{{ asset_url(path='custom.css') }}" />
+<link rel="stylesheet" href="{{ asset_url(path='custom.css') }}?v={{ site_asset_version }}" />
 {% endif %}

--- a/assets/themes/journal/templates/partials/head_assets.html
+++ b/assets/themes/journal/templates/partials/head_assets.html
@@ -1,7 +1,7 @@
-{% if site_favicon_svg %}<link rel="icon" href="{{ site_favicon_svg }}" type="image/svg+xml" />{% endif %}
-{% if site_favicon_ico %}<link rel="icon" href="{{ site_favicon_ico }}" sizes="any" />{% endif %}
-{% if site_apple_touch_icon %}<link rel="apple-touch-icon" href="{{ site_apple_touch_icon }}" />{% endif %}
-{% if site_favicon and not site_favicon_svg and not site_favicon_ico %}<link rel="icon" href="{{ site_favicon }}" />{% endif %}
+{% if site_favicon_svg %}<link rel="icon" href="{{ site_favicon_svg }}?v={{ site_asset_version }}" type="image/svg+xml" />{% endif %}
+{% if site_favicon_ico %}<link rel="icon" href="{{ site_favicon_ico }}?v={{ site_asset_version }}" sizes="any" />{% endif %}
+{% if site_apple_touch_icon %}<link rel="apple-touch-icon" href="{{ site_apple_touch_icon }}?v={{ site_asset_version }}" />{% endif %}
+{% if site_favicon and not site_favicon_svg and not site_favicon_ico %}<link rel="icon" href="{{ site_favicon }}?v={{ site_asset_version }}" />{% endif %}
 <style>
   :root {
     --rustipo-content-width: {{ site_style.content_width | default(value="1120px") }};
@@ -18,8 +18,8 @@
   {{ site_font_faces_css | safe }}
 </style>
 {% endif %}
-<link rel="stylesheet" href="{{ asset_url(path='style.css') }}" />
-<link rel="stylesheet" href="{{ asset_url(path='palette.css') }}" />
+<link rel="stylesheet" href="{{ asset_url(path='style.css') }}?v={{ site_asset_version }}" />
+<link rel="stylesheet" href="{{ asset_url(path='palette.css') }}?v={{ site_asset_version }}" />
 {% if site_has_custom_css %}
-<link rel="stylesheet" href="{{ asset_url(path='custom.css') }}" />
+<link rel="stylesheet" href="{{ asset_url(path='custom.css') }}?v={{ site_asset_version }}" />
 {% endif %}

--- a/src/commands/new/scaffold.rs
+++ b/src/commands/new/scaffold.rs
@@ -106,10 +106,10 @@ pub const HEAD_ASSETS_PARTIAL: &str = r#"{% if site_favicon_svg %}<link rel="ico
   {{ site_font_faces_css | safe }}
 </style>
 {% endif %}
-<link rel="stylesheet" href="{{ asset_url(path='style.css') }}" />
-<link rel="stylesheet" href="{{ asset_url(path='palette.css') }}" />
+<link rel="stylesheet" href="{{ asset_url(path='style.css') }}?v={{ site_asset_version }}" />
+<link rel="stylesheet" href="{{ asset_url(path='palette.css') }}?v={{ site_asset_version }}" />
 {% if site_has_custom_css %}
-<link rel="stylesheet" href="{{ asset_url(path='custom.css') }}" />
+<link rel="stylesheet" href="{{ asset_url(path='custom.css') }}?v={{ site_asset_version }}" />
 {% endif %}
 "#;
 

--- a/src/commands/site.rs
+++ b/src/commands/site.rs
@@ -1,4 +1,8 @@
-use anyhow::Result;
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use walkdir::WalkDir;
 
 use crate::config::SiteConfig;
 use crate::content::pages::{Page, PublicationMode, build_pages, build_pages_for_mode};
@@ -45,6 +49,7 @@ pub(crate) fn prepare_site(
     let site_font_faces_css =
         (!font_faces.is_empty()).then(|| crate::config::fonts::render_font_faces_css(&font_faces));
     let site_has_custom_css = config.has_custom_css(".");
+    let asset_version = compute_asset_version(".", &theme.static_dirs, &palette)?;
     let pages = match publication_mode {
         PublicationMode::Production => build_pages("content")?,
         PublicationMode::Preview => build_pages_for_mode("content", PublicationMode::Preview)?,
@@ -58,6 +63,7 @@ pub(crate) fn prepare_site(
         site_style: &site_style,
         site_has_custom_css,
         site_font_faces_css: site_font_faces_css.as_deref(),
+        asset_version: &asset_version,
         palette: &palette,
     };
     let rendered_pages =
@@ -77,4 +83,63 @@ pub(crate) fn prepare_site(
         rendered_pages,
         not_found_html,
     })
+}
+
+fn compute_asset_version(
+    project_root: impl AsRef<Path>,
+    theme_static_dirs: &[std::path::PathBuf],
+    palette: &Palette,
+) -> Result<String> {
+    let mut hash = 0xcbf29ce484222325_u64;
+    hash_static_dir(&mut hash, project_root.as_ref().join("static"))?;
+
+    for dir in theme_static_dirs {
+        hash_static_dir(&mut hash, dir)?;
+    }
+
+    let palette_json = serde_json::to_vec(palette).context("failed to serialize palette")?;
+    hash_bytes(&mut hash, &palette_json);
+
+    Ok(format!("{hash:016x}"))
+}
+
+fn hash_static_dir(hash: &mut u64, dir: impl AsRef<Path>) -> Result<()> {
+    let dir = dir.as_ref();
+    if !dir.exists() {
+        return Ok(());
+    }
+
+    let mut files = WalkDir::new(dir)
+        .into_iter()
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .with_context(|| format!("failed to walk static asset directory: {}", dir.display()))?;
+    files.sort_by(|left, right| left.path().cmp(right.path()));
+
+    for entry in files {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+
+        let relative = entry.path().strip_prefix(dir).with_context(|| {
+            format!(
+                "failed to compute static asset relative path: {}",
+                entry.path().display()
+            )
+        })?;
+        hash_bytes(hash, relative.to_string_lossy().as_bytes());
+        hash_bytes(hash, &[0]);
+        let bytes = fs::read(entry.path())
+            .with_context(|| format!("failed to read static asset: {}", entry.path().display()))?;
+        hash_bytes(hash, &bytes);
+        hash_bytes(hash, &[0xff]);
+    }
+
+    Ok(())
+}
+
+fn hash_bytes(hash: &mut u64, bytes: &[u8]) {
+    for byte in bytes {
+        *hash ^= u64::from(*byte);
+        *hash = hash.wrapping_mul(0x100000001b3);
+    }
 }

--- a/src/render/templates/mod.rs
+++ b/src/render/templates/mod.rs
@@ -28,6 +28,7 @@ pub struct SiteRenderContext<'a> {
     pub site_style: &'a SiteStyleOptions,
     pub site_has_custom_css: bool,
     pub site_font_faces_css: Option<&'a str>,
+    pub asset_version: &'a str,
     pub palette: &'a Palette,
 }
 
@@ -115,6 +116,7 @@ fn insert_common_site_context(
         "site_font_faces_css",
         &render_context.site.site_font_faces_css,
     );
+    context.insert("site_asset_version", &render_context.site.asset_version);
     context::insert_page_context(
         context,
         config,

--- a/src/render/templates/tests.rs
+++ b/src/render/templates/tests.rs
@@ -82,6 +82,7 @@ fn renders_pages_with_theme_templates() {
             site_style: &site_style,
             site_has_custom_css,
             site_font_faces_css: None,
+            asset_version: "test",
             palette: &palette,
         },
     )
@@ -198,6 +199,7 @@ fn supports_tera_includes_macros_inheritance_and_rustipo_helpers() {
             site_style: &site_style,
             site_has_custom_css,
             site_font_faces_css: None,
+            asset_version: "test",
             palette: &palette,
         },
     )
@@ -306,6 +308,7 @@ fn paginates_blog_section_when_posts_exceed_page_size() {
             site_style: &site_style,
             site_has_custom_css,
             site_font_faces_css: None,
+            asset_version: "test",
             palette: &palette,
         },
     )
@@ -384,6 +387,7 @@ fn exposes_page_toc_to_templates() {
             site_style: &site_style,
             site_has_custom_css,
             site_font_faces_css: None,
+            asset_version: "test",
             palette: &palette,
         },
     )
@@ -474,6 +478,7 @@ fn renders_archive_groups_for_dated_posts() {
             site_style: &site_style,
             site_has_custom_css,
             site_font_faces_css: None,
+            asset_version: "test",
             palette: &palette,
         },
     )
@@ -572,6 +577,7 @@ fn exposes_frontmatter_metadata_in_page_templates() {
             site_style: &site_style,
             site_has_custom_css,
             site_font_faces_css: None,
+            asset_version: "test",
             palette: &palette,
         },
     )
@@ -690,6 +696,7 @@ fn exposes_navigation_adjacency_and_helper_context() {
             site_style: &site_style,
             site_has_custom_css,
             site_font_faces_css: None,
+            asset_version: "test",
             palette: &palette,
         },
     )
@@ -835,6 +842,7 @@ fn exposes_configured_site_menus_and_uses_main_for_site_nav() {
             site_style: &site_style,
             site_has_custom_css,
             site_font_faces_css: None,
+            asset_version: "test",
             palette: &palette,
         },
     )
@@ -941,6 +949,7 @@ fn exposes_breadcrumbs_for_top_level_and_nested_pages() {
             site_style: &site_style,
             site_has_custom_css,
             site_font_faces_css: None,
+            asset_version: "test",
             palette: &palette,
         },
     )
@@ -1046,6 +1055,7 @@ fn injects_mermaid_runtime_only_for_pages_with_mermaid() {
             site_style: &site_style,
             site_has_custom_css,
             site_font_faces_css: None,
+            asset_version: "test",
             palette: &palette,
         },
     )
@@ -1139,6 +1149,7 @@ fn injects_math_runtime_only_for_pages_with_math() {
             site_style: &site_style,
             site_has_custom_css,
             site_font_faces_css: None,
+            asset_version: "test",
             palette: &palette,
         },
     )
@@ -1237,6 +1248,7 @@ fn renders_not_found_page_with_page_template_fallback() {
             site_style: &site_style,
             site_has_custom_css,
             site_font_faces_css: None,
+            asset_version: "test",
             palette: &palette,
         },
     )
@@ -1317,6 +1329,7 @@ fn prefers_dedicated_not_found_template_when_present() {
             site_style: &site_style,
             site_has_custom_css,
             site_font_faces_css: None,
+            asset_version: "test",
             palette: &palette,
         },
     )
@@ -1346,7 +1359,7 @@ fn prefixes_rendered_public_urls_when_base_url_has_subpath() {
 
     fs::write(
         theme_root.join("templates/base.html"),
-        "<html><head><link rel=\"stylesheet\" href=\"{{ asset_url(path='style.css') }}\"></head><body><a class=\"home\" href=\"{{ site_root }}\">Home</a>{% block body %}{% endblock body %}</body></html>",
+        "<html><head><link rel=\"stylesheet\" href=\"{{ asset_url(path='style.css') }}?v={{ site_asset_version }}\"></head><body><a class=\"home\" href=\"{{ site_root }}\">Home</a>{% block body %}{% endblock body %}</body></html>",
     )
     .expect("base template should be written");
     for template in [
@@ -1398,6 +1411,7 @@ fn prefixes_rendered_public_urls_when_base_url_has_subpath() {
             site_style: &site_style,
             site_has_custom_css,
             site_font_faces_css: None,
+            asset_version: "test",
             palette: &palette,
         },
     )
@@ -1408,7 +1422,11 @@ fn prefixes_rendered_public_urls_when_base_url_has_subpath() {
         .find(|page| page.route == "/")
         .expect("index page should render");
 
-    assert!(index.html.contains("href=\"&#x2F;rustipo&#x2F;style.css\""));
+    assert!(
+        index
+            .html
+            .contains("href=\"&#x2F;rustipo&#x2F;style.css?v=test\"")
+    );
     assert!(
         index
             .html


### PR DESCRIPTION
## Summary
- let the Atlas sidebar collapse and reopen on desktop as well as mobile
- keep the back-to-top button tied to actual scroll position
- fingerprint theme and static assets so GitHub Pages stops serving stale CSS after theme updates

## Verification
- cargo fmt --all
- cargo test -q
- cd site && cargo run --quiet --manifest-path ../Cargo.toml -- build
- manual browser check of desktop sidebar toggle, mobile drawer, and back-to-top behavior