### PR TITLE
fix(theme): restore atlas static sidebar

### DIFF
--- a/assets/themes/atlas/static/style.css
+++ b/assets/themes/atlas/static/style.css
@@ -27,10 +27,6 @@ body {
   min-height: 100vh;
 }
 
-body.docs-sidebar-collapsed .docs-shell {
-  grid-template-columns: minmax(0, 1fr);
-}
-
 .docs-sidebar {
   position: sticky;
   top: 0;
@@ -41,14 +37,9 @@ body.docs-sidebar-collapsed .docs-shell {
   background: color-mix(in srgb, var(--rustipo-mantle) 82%, var(--rustipo-base) 18%);
 }
 
-body.docs-sidebar-collapsed .docs-sidebar {
-  display: none;
-}
-
 .docs-sidebar-head {
   display: flex;
   align-items: flex-start;
-  justify-content: space-between;
   gap: 0.9rem;
 }
 
@@ -80,54 +71,16 @@ body.docs-sidebar-collapsed .docs-sidebar {
   margin-top: 1.25rem;
 }
 
-.docs-menu-toggle,
-.docs-sidebar-close,
-.docs-overlay,
 .back-to-top {
   font: inherit;
 }
 
-.docs-menu-toggle,
-.docs-sidebar-close,
 .back-to-top {
   border: 1px solid var(--rustipo-surface-1, var(--rustipo-border));
   border-radius: 999px;
   background: color-mix(in srgb, var(--rustipo-mantle) 78%, var(--rustipo-base) 22%);
   color: var(--rustipo-text);
   box-shadow: 0 16px 36px color-mix(in srgb, var(--rustipo-mantle) 34%, transparent);
-}
-
-.docs-menu-toggle,
-.docs-sidebar-close {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-}
-
-.docs-menu-toggle {
-  position: fixed;
-  top: 1rem;
-  left: 1rem;
-  z-index: 60;
-  padding: 0.6rem 0.9rem;
-}
-
-.docs-sidebar-close {
-  padding: 0.45rem 0.75rem;
-  white-space: nowrap;
-}
-
-.docs-overlay {
-  display: none;
-  position: fixed;
-  inset: 0;
-  border: 0;
-  background: color-mix(in srgb, var(--rustipo-mantle) 55%, transparent);
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 180ms ease;
-  z-index: 25;
 }
 
 .back-to-top {
@@ -184,11 +137,6 @@ body.docs-sidebar-collapsed .docs-sidebar {
   width: 100%;
   max-width: calc(var(--rustipo-content-width) + 4rem);
   padding: 1.5rem 1.5rem 3rem;
-}
-
-body.docs-sidebar-collapsed .docs-main {
-  max-width: min(1600px, calc(var(--rustipo-content-width) + 22rem));
-  padding-left: 5.2rem;
 }
 
 .docs-content-grid {
@@ -370,46 +318,15 @@ body.docs-sidebar-collapsed .docs-main {
     grid-template-columns: 1fr;
   }
 
-  body.docs-sidebar-collapsed .docs-sidebar {
-    display: block;
-  }
-
   .docs-sidebar {
-    position: fixed;
-    inset: 0 auto 0 0;
-    z-index: 50;
-    width: min(82vw, 320px);
-    min-height: 100vh;
-    border-right: 1px solid var(--rustipo-surface-1, var(--rustipo-border));
-    border-bottom: 0;
-    overflow-y: auto;
-    transform: translateX(-105%);
-    transition: transform 180ms ease;
-  }
-
-  body.docs-sidebar-open .docs-sidebar {
-    transform: translateX(0);
-  }
-
-  body.docs-sidebar-open {
-    overflow: hidden;
-  }
-
-  .docs-overlay {
-    display: block;
-  }
-
-  body.docs-sidebar-open .docs-overlay {
-    opacity: 1;
-    pointer-events: auto;
+    position: static;
+    min-height: auto;
+    border-right: 0;
+    border-bottom: 1px solid var(--rustipo-surface-1, var(--rustipo-border));
   }
 
   .docs-main {
-    padding: 4.6rem 1rem 2rem;
-  }
-
-  body.docs-sidebar-collapsed .docs-main {
-    padding: 4.6rem 1rem 2rem;
+    padding: 1.1rem 1rem 2rem;
   }
 
   .doc-card {

--- a/assets/themes/atlas/templates/base.html
+++ b/assets/themes/atlas/templates/base.html
@@ -8,35 +8,16 @@
     {% include "partials/head_assets.html" %}
   </head>
   <body>
-    <button
-      class="docs-menu-toggle"
-      id="docsMenuToggle"
-      type="button"
-      aria-controls="docsSidebar"
-      aria-expanded="false"
-    >
-      <span aria-hidden="true">Menu</span>
-    </button>
-    <button
-      class="docs-overlay"
-      id="docsOverlay"
-      type="button"
-      aria-label="Close navigation"
-      hidden
-    ></button>
-    <button class="back-to-top" id="docsBackToTop" type="button" aria-label="Back to top">
+    <button class="back-to-top" id="docsBackToTop" type="button" aria-label="Back to top" hidden>
       Top
     </button>
     <div class="docs-shell">
-      <aside class="docs-sidebar" id="docsSidebar">
+      <aside class="docs-sidebar">
         <div class="docs-sidebar-head">
           <div>
             <a class="docs-brand" href="{{ site_root }}">{{ site_title }}</a>
             <p class="docs-tagline">{{ site_description }}</p>
           </div>
-          <button class="docs-sidebar-close" id="docsSidebarClose" type="button" aria-label="Close navigation">
-            Close
-          </button>
         </div>
         <nav class="docs-nav" aria-label="Primary navigation">
           {% for item in site_nav %}
@@ -67,69 +48,16 @@
     </div>
     <script>
       (() => {
-        const sidebar = document.getElementById("docsSidebar");
-        const menuToggle = document.getElementById("docsMenuToggle");
-        const sidebarClose = document.getElementById("docsSidebarClose");
-        const overlay = document.getElementById("docsOverlay");
         const backToTop = document.getElementById("docsBackToTop");
 
-        if (!sidebar || !menuToggle || !sidebarClose || !overlay || !backToTop) {
+        if (!backToTop) {
           return;
         }
 
-        const mobileQuery = window.matchMedia("(max-width: 860px)");
-
-        const isMobile = () => mobileQuery.matches;
-
-        const isSidebarOpen = () => {
-          if (isMobile()) {
-            return document.body.classList.contains("docs-sidebar-open");
-          }
-
-          return !document.body.classList.contains("docs-sidebar-collapsed");
-        };
-
-        const setSidebarOpen = (open) => {
-          if (isMobile()) {
-            document.body.classList.toggle("docs-sidebar-open", open);
-            document.body.classList.remove("docs-sidebar-collapsed");
-            overlay.hidden = !open;
-          } else {
-            document.body.classList.remove("docs-sidebar-open");
-            document.body.classList.toggle("docs-sidebar-collapsed", !open);
-            overlay.hidden = true;
-          }
-
-          menuToggle.setAttribute("aria-expanded", String(open));
-        };
-
-        const syncDrawerMode = () => {
-          setSidebarOpen(!isMobile());
-        };
-
-        menuToggle.addEventListener("click", () => {
-          setSidebarOpen(!isSidebarOpen());
-        });
-
-        sidebarClose.addEventListener("click", () => setSidebarOpen(false));
-        overlay.addEventListener("click", () => setSidebarOpen(false));
-
-        document.addEventListener("keydown", (event) => {
-          if (event.key === "Escape" && isSidebarOpen()) {
-            setSidebarOpen(false);
-          }
-        });
-
-        sidebar.querySelectorAll("a").forEach((link) => {
-          link.addEventListener("click", () => {
-            if (isMobile()) {
-              setSidebarOpen(false);
-            }
-          });
-        });
-
         const syncBackToTop = () => {
-          backToTop.classList.toggle("is-visible", window.scrollY > 320);
+          const visible = window.scrollY > 320;
+          backToTop.hidden = !visible;
+          backToTop.classList.toggle("is-visible", visible);
         };
 
         backToTop.addEventListener("click", () => {
@@ -137,14 +65,6 @@
         });
 
         window.addEventListener("scroll", syncBackToTop, { passive: true });
-
-        if (typeof mobileQuery.addEventListener === "function") {
-          mobileQuery.addEventListener("change", syncDrawerMode);
-        } else {
-          mobileQuery.addListener(syncDrawerMode);
-        }
-
-        syncDrawerMode();
         syncBackToTop();
       })();
     </script>


### PR DESCRIPTION
## Summary
- remove the Atlas drawer behavior and restore the original static sidebar layout
- keep the separate asset cache-busting fix from the previous patch intact
- keep the back-to-top button behavior independent from sidebar navigation

## Verification
- cargo test -q
- cd site && cargo run --quiet --manifest-path ../Cargo.toml -- build
- manual browser check of the Atlas roadmap page layout