### PR TITLE
ci(release): sync homebrew tap after releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -157,3 +157,53 @@ jobs:
           tag_name: ${{ needs.release-please.outputs.tag_name }}
           files: release-assets/*
           fail_on_unmatched_files: true
+
+  sync-homebrew-tap:
+    name: Sync Homebrew tap
+    runs-on: ubuntu-latest
+    needs:
+      - release-please
+      - publish-release-assets
+    if: ${{ needs.release-please.outputs.release_created == 'true' && needs.release-please.outputs.tag_name != '' && secrets.HOMEBREW_TAP_TOKEN != '' }}
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_TAG: ${{ needs.release-please.outputs.tag_name }}
+    steps:
+      - name: Check out Rustipo release tag
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - name: Check out Homebrew tap
+        uses: actions/checkout@v6
+        with:
+          repository: fcendesu/homebrew-rustipo
+          path: homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - name: Update in-repo formula from release checksums
+        run: ./scripts/update-homebrew-formula.sh "$RELEASE_TAG"
+
+      - name: Copy formula into tap repository
+        run: |
+          set -euo pipefail
+          mkdir -p homebrew-tap/Formula
+          cp Formula/rustipo.rb homebrew-tap/Formula/rustipo.rb
+
+      - name: Commit and push tap update
+        working-directory: homebrew-tap
+        env:
+          RELEASE_TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- Formula/rustipo.rb; then
+            echo "No Homebrew formula changes to publish."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/rustipo.rb
+          git commit -m "chore(formula): update rustipo for ${RELEASE_TAG#rustipo-v}"
+          git push origin HEAD:main

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -17,6 +17,7 @@ Checks run on push and pull request:
 
 - Release Please runs manually via workflow dispatch when maintainers want to prepare a release.
 - When a release is created, the same workflow also builds prebuilt binaries for the main supported targets and uploads them, plus a checksum file, to the GitHub release.
+- If `HOMEBREW_TAP_TOKEN` is configured, the same workflow also syncs `Formula/rustipo.rb` into `fcendesu/homebrew-rustipo`.
 - CI remains automatic for pushes and pull requests.
 
 ## Maintainer release docs

--- a/docs/release.md
+++ b/docs/release.md
@@ -17,7 +17,8 @@ This document is for maintainers preparing a Rustipo release and publishing it t
   - `.github/release-please/manifest.json`
 - When a release is created, the workflow syncs the GitHub release body from the generated Release Please notes.
 - The same workflow builds prebuilt binary archives for the main supported targets and uploads them, plus a SHA-256 checksum file, to the GitHub release.
-- The repository also contains the Homebrew tap formula at `Formula/rustipo.rb`.
+- The repository also contains the source-of-truth Homebrew formula at `Formula/rustipo.rb`.
+- When `HOMEBREW_TAP_TOKEN` is configured in GitHub Actions secrets, the release workflow syncs that formula into `fcendesu/homebrew-rustipo` after the release assets are uploaded.
 - The release PR updates:
   - `Cargo.toml`
   - `CHANGELOG.md`
@@ -82,34 +83,52 @@ cargo publish
 
 ## Homebrew formula maintenance
 
-Rustipo uses this repository itself as the Homebrew tap. macOS users can install it with:
+Rustipo publishes Homebrew installs through the separate tap repository `fcendesu/homebrew-rustipo`.
+macOS users can install it with:
 
 ```bash
 brew install fcendesu/rustipo/rustipo
 ```
 
-After a release is finalized and the GitHub release assets exist:
+The main repository keeps the source-of-truth formula in `Formula/rustipo.rb`.
+
+### Required secret
+
+To let the release workflow update the public tap automatically, configure this repository secret:
+
+- `HOMEBREW_TAP_TOKEN`
+  - a GitHub token with write access to `fcendesu/homebrew-rustipo`
+
+### Automatic sync behavior
+
+After a release is finalized and the GitHub release assets exist, the release workflow will:
+
+1. run `./scripts/update-homebrew-formula.sh <tag>` in the Rustipo checkout
+2. copy the resulting `Formula/rustipo.rb` into `fcendesu/homebrew-rustipo`
+3. commit and push the tap update automatically
+
+### Manual fallback
+
+If the secret is missing or the automated sync fails, you can still update the tap manually:
 
 1. Update the formula from the release checksum file.
 
 ```bash
-./scripts/update-homebrew-formula.sh rustipo-v0.10.0
+./scripts/update-homebrew-formula.sh rustipo-v0.11.0
 ```
 
 2. Review the resulting `Formula/rustipo.rb` change.
-3. Commit the formula update on your branch.
-4. Validate the tap from the branch checkout.
+3. Copy that file into `fcendesu/homebrew-rustipo/Formula/rustipo.rb`.
+4. Commit and push the tap repo update.
+5. Validate the public tap.
 
 ```bash
-brew tap fcendesu/rustipo "$(pwd)"
-brew audit --strict fcendesu/rustipo/rustipo
+brew tap fcendesu/rustipo
 brew install fcendesu/rustipo/rustipo
 brew test rustipo
 brew uninstall --force rustipo
 brew untap fcendesu/rustipo
 ```
-
-5. Merge the formula update to `master`.
 
 ## Relationship between release prep and crates.io publish
 


### PR DESCRIPTION
## Summary\n- sync the Homebrew tap automatically after release assets are published\n- document the required HOMEBREW_TAP_TOKEN secret and fallback flow\n\n## Testing\n- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-please.yml"); YAML.load_file(".github/workflows/docs-site.yml")'