### PR TITLE
chore(release): harden homebrew tap sync

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,15 +6,16 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -55,6 +56,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -137,6 +140,8 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created == 'true' && needs.release-please.outputs.tag_name != '' }}
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+    permissions:
+      contents: write
     steps:
       - name: Download packaged release archives
         uses: actions/download-artifact@v8
@@ -167,13 +172,16 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created == 'true' && needs.release-please.outputs.tag_name != '' && secrets.HOMEBREW_TAP_TOKEN != '' }}
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-      GH_TOKEN: ${{ github.token }}
       RELEASE_TAG: ${{ needs.release-please.outputs.tag_name }}
+    permissions:
+      contents: read
     steps:
       - name: Check out Rustipo release tag
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
+          fetch-depth: 1
+          persist-credentials: false
 
       - name: Check out Homebrew tap
         uses: actions/checkout@v6
@@ -181,6 +189,7 @@ jobs:
           repository: fcendesu/homebrew-rustipo
           path: homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          fetch-depth: 1
 
       - name: Update in-repo formula from release checksums
         run: ./scripts/update-homebrew-formula.sh "$RELEASE_TAG"

--- a/docs/release.md
+++ b/docs/release.md
@@ -97,7 +97,12 @@ The main repository keeps the source-of-truth formula in `Formula/rustipo.rb`.
 To let the release workflow update the public tap automatically, configure this repository secret:
 
 - `HOMEBREW_TAP_TOKEN`
-  - a GitHub token with write access to `fcendesu/homebrew-rustipo`
+  - use a dedicated fine-grained GitHub personal access token
+  - scope it only to `fcendesu/homebrew-rustipo`
+  - grant:
+    - repository contents: `Read and write`
+    - metadata: `Read`
+  - do not reuse a broad personal token from your main developer account if you can avoid it
 
 ### Automatic sync behavior
 
@@ -116,6 +121,9 @@ If the secret is missing or the automated sync fails, you can still update the t
 ```bash
 ./scripts/update-homebrew-formula.sh rustipo-v0.11.0
 ```
+
+The script downloads the public release checksum file directly from GitHub Releases and does not
+require `gh auth` or a maintainer token.
 
 2. Review the resulting `Formula/rustipo.rb` change.
 3. Copy that file into `fcendesu/homebrew-rustipo/Formula/rustipo.rb`.

--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -20,9 +20,15 @@ formula_path="$repo_root/Formula/rustipo.rb"
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 
-gh release download "$tag" --pattern "${tag}-sha256sums.txt" --dir "$tmpdir" >/dev/null
-
 checksum_file="$tmpdir/${tag}-sha256sums.txt"
+repo_slug="${RUSTIPO_GITHUB_REPO:-fcendesu/rustipo}"
+checksum_url="https://github.com/${repo_slug}/releases/download/${tag}/${tag}-sha256sums.txt"
+
+curl --fail --silent --show-error --location \
+  --retry 3 \
+  --output "$checksum_file" \
+  "$checksum_url"
+
 arm_sha="$(awk "/${tag}-aarch64-apple-darwin\\.tar\\.gz$/ { print \$1 }" "$checksum_file")"
 intel_sha="$(awk "/${tag}-x86_64-apple-darwin\\.tar\\.gz$/ { print \$1 }" "$checksum_file")"
 


### PR DESCRIPTION
## Summary\n- tighten release workflow permissions for the Homebrew sync path\n- stop requiring gh auth for the formula updater by downloading public checksums directly\n- document the dedicated fine-grained token requirements for HOMEBREW_TAP_TOKEN\n\n## Testing\n- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-please.yml")'\n- ./scripts/update-homebrew-formula.sh rustipo-v0.11.0