### PR TITLE
feat(theme): add default meta description support

### DIFF
--- a/assets/themes/atlas/templates/partials/head_assets.html
+++ b/assets/themes/atlas/templates/partials/head_assets.html
@@ -2,6 +2,7 @@
 {% if site_favicon_ico %}<link rel="icon" href="{{ site_favicon_ico }}?v={{ site_asset_version }}" sizes="any" />{% endif %}
 {% if site_apple_touch_icon %}<link rel="apple-touch-icon" href="{{ site_apple_touch_icon }}?v={{ site_asset_version }}" />{% endif %}
 {% if site_favicon and not site_favicon_svg and not site_favicon_ico %}<link rel="icon" href="{{ site_favicon }}?v={{ site_asset_version }}" />{% endif %}
+{% if page_description %}<meta name="description" content="{{ page_description }}" />{% endif %}
 <style>
   :root {
     --rustipo-content-width: {{ site_style.content_width | default(value="1280px") }};

--- a/assets/themes/journal/templates/partials/head_assets.html
+++ b/assets/themes/journal/templates/partials/head_assets.html
@@ -2,6 +2,7 @@
 {% if site_favicon_ico %}<link rel="icon" href="{{ site_favicon_ico }}?v={{ site_asset_version }}" sizes="any" />{% endif %}
 {% if site_apple_touch_icon %}<link rel="apple-touch-icon" href="{{ site_apple_touch_icon }}?v={{ site_asset_version }}" />{% endif %}
 {% if site_favicon and not site_favicon_svg and not site_favicon_ico %}<link rel="icon" href="{{ site_favicon }}?v={{ site_asset_version }}" />{% endif %}
+{% if page_description %}<meta name="description" content="{{ page_description }}" />{% endif %}
 <style>
   :root {
     --rustipo-content-width: {{ site_style.content_width | default(value="1120px") }};

--- a/docs/content-model.md
+++ b/docs/content-model.md
@@ -47,7 +47,9 @@ Supported fields for MVP:
 - `order`
 - `links`
 
-These frontmatter fields are exposed to page templates under `frontmatter` and page-level convenience keys (for example `page_date`, `page_summary`, `page_tags`).
+These frontmatter fields are exposed to page templates under `frontmatter` and page-level convenience keys (for example `page_date`, `page_summary`, `page_description`, `page_tags`).
+
+`summary` is also the first input Rustipo uses for built-in meta description rendering in themes. If `summary` is empty, Rustipo falls back to the site-level `description` from `config.toml`.
 
 ## Content vs layout
 

--- a/docs/implemented-features.md
+++ b/docs/implemented-features.md
@@ -237,6 +237,7 @@
 - `page_title`
 - `page_date`
 - `page_summary`
+- `page_description`
 - `page_tags`
 - `page_has_math`
 - `page_toc`
@@ -248,6 +249,13 @@
 - `previous_post`
 - `next_post`
 - `page_has_mermaid`
+
+## Built-in Metadata Output
+
+- default `<meta name="description">` support in built-in themes
+- resolution order:
+  - `page_summary`
+  - `site_description`
 - `route`
 - `section_name`
 - `section_title`

--- a/docs/theme-contract.md
+++ b/docs/theme-contract.md
@@ -156,6 +156,7 @@ Rustipo injects common site variables into template contexts, including:
 - page-state helpers:
   - `page_kind`
   - `current_section`
+  - `page_description`
   - `site_nav`
   - `site_menus`
   - `breadcrumbs`
@@ -179,6 +180,13 @@ Rustipo injects common site variables into template contexts, including:
   - `site_style.mono_font`
 - `site_has_custom_css` (boolean, true when `static/custom.css` exists)
 - `site_font_faces_css` (optional rendered `@font-face` rules for configured local fonts)
+
+`page_description` is the stable convenience field for theme metadata output. It resolves with this fallback order:
+
+- `page_summary`
+- `site_description`
+
+If both values are empty, Rustipo leaves `page_description` unset so themes can omit the tag cleanly.
 
 Rustipo also registers small Tera helpers for theme authors:
 

--- a/docs/theme-tera.md
+++ b/docs/theme-tera.md
@@ -70,6 +70,7 @@ Rustipo injects common values such as:
 - `page_title`
 - `page_date`
 - `page_summary`
+- `page_description`
 - `page_tags`
 - `page_has_math`
 - `page_toc`
@@ -77,6 +78,13 @@ Rustipo injects common values such as:
 - `site_description`
 - `site_asset_version`
 - `site_style.*`
+
+`page_description` is the built-in convenience value for metadata tags. Rustipo resolves it with this fallback order:
+
+- `page_summary`
+- `site_description`
+
+If both are empty, `page_description` is omitted.
 
 Rustipo also injects stable navigation and page-state values:
 

--- a/src/commands/new/scaffold.rs
+++ b/src/commands/new/scaffold.rs
@@ -90,6 +90,7 @@ pub const HEAD_ASSETS_PARTIAL: &str = r#"{% if site_favicon_svg %}<link rel="ico
 {% if site_favicon_ico %}<link rel="icon" href="{{ site_favicon_ico }}" sizes="any" />{% endif %}
 {% if site_apple_touch_icon %}<link rel="apple-touch-icon" href="{{ site_apple_touch_icon }}" />{% endif %}
 {% if site_favicon and not site_favicon_svg and not site_favicon_ico %}<link rel="icon" href="{{ site_favicon }}" />{% endif %}
+{% if page_description %}<meta name="description" content="{{ page_description }}" />{% endif %}
 <style>
   :root {
     --rustipo-content-width: {{ site_style.content_width | default(value="98%") }};

--- a/src/render/templates/archive.rs
+++ b/src/render/templates/archive.rs
@@ -83,6 +83,10 @@ pub(super) fn render_blog_archive_page(
     };
     super::insert_common_site_context(&mut context, env.config, &render_context);
     context.insert("page_title", &format!("Archive | {}", env.config.title));
+    context.insert(
+        "page_description",
+        &super::resolved_page_description(None, env.config),
+    );
     context.insert("content_html", "");
     context.insert("page_has_mermaid", &false);
     context.insert("page_has_math", &false);

--- a/src/render/templates/mod.rs
+++ b/src/render/templates/mod.rs
@@ -127,6 +127,20 @@ fn insert_common_site_context(
     );
 }
 
+pub(super) fn resolved_page_description(
+    page_summary: Option<&str>,
+    config: &SiteConfig,
+) -> Option<String> {
+    page_summary
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            let site_description = config.description.trim();
+            (!site_description.is_empty()).then(|| site_description.to_string())
+        })
+}
+
 pub(super) fn rewrite_public_html_urls(html: &str, config: &SiteConfig) -> String {
     let base_path = crate::url::base_path(&config.base_url);
     if base_path == "/" {

--- a/src/render/templates/not_found.rs
+++ b/src/render/templates/not_found.rs
@@ -42,6 +42,10 @@ pub(super) fn render_not_found_page(tera: &Tera, env: &RenderEnvironment<'_>) ->
     context.insert("frontmatter", &frontmatter);
     context.insert("page_summary", &frontmatter.summary);
     context.insert(
+        "page_description",
+        &super::resolved_page_description(frontmatter.summary.as_deref(), env.config),
+    );
+    context.insert(
         "page_date",
         &frontmatter.date.as_ref().map(ToString::to_string),
     );

--- a/src/render/templates/page.rs
+++ b/src/render/templates/page.rs
@@ -44,6 +44,10 @@ pub(super) fn render_content_pages(
         context.insert("frontmatter", &page.frontmatter);
         context.insert("page_summary", &page.frontmatter.summary);
         context.insert(
+            "page_description",
+            &super::resolved_page_description(page.frontmatter.summary.as_deref(), env.config),
+        );
+        context.insert(
             "page_date",
             &page.frontmatter.date.as_ref().map(ToString::to_string),
         );

--- a/src/render/templates/section.rs
+++ b/src/render/templates/section.rs
@@ -98,6 +98,10 @@ fn render_blog_section_pages(
         };
         super::insert_common_site_context(&mut context, env.config, &render_context);
         context.insert("page_title", &format!("Blog | {}", env.config.title));
+        context.insert(
+            "page_description",
+            &super::resolved_page_description(None, env.config),
+        );
         context.insert("content_html", "");
         context.insert("page_has_mermaid", &false);
         context.insert("page_has_math", &false);
@@ -150,6 +154,10 @@ fn render_projects_section_page(
     };
     super::insert_common_site_context(&mut context, env.config, &render_context);
     context.insert("page_title", &format!("Projects | {}", env.config.title));
+    context.insert(
+        "page_description",
+        &super::resolved_page_description(None, env.config),
+    );
     context.insert("content_html", "");
     context.insert("page_has_mermaid", &false);
     context.insert("page_has_math", &false);

--- a/src/render/templates/tags.rs
+++ b/src/render/templates/tags.rs
@@ -73,6 +73,10 @@ pub(super) fn render_tag_pages(
             "page_title",
             &format!("Tag: {tag_slug} | {}", env.config.title),
         );
+        context.insert(
+            "page_description",
+            &super::resolved_page_description(None, env.config),
+        );
         context.insert("content_html", "");
         context.insert("page_has_mermaid", &false);
         context.insert("page_has_math", &false);

--- a/src/render/templates/tests.rs
+++ b/src/render/templates/tests.rs
@@ -529,7 +529,7 @@ fn exposes_frontmatter_metadata_in_page_templates() {
     .expect("page template should be written");
     fs::write(
         theme_root.join("templates/post.html"),
-        "{% extends \"base.html\" %}{% block body %}<time>{{ frontmatter.date }}</time><p>{{ frontmatter.summary }}</p><div>{{ page_date }}</div><div>{{ page_summary }}</div>{{ content_html | safe }}{% endblock body %}",
+        "{% extends \"base.html\" %}{% block body %}<time>{{ frontmatter.date }}</time><p>{{ frontmatter.summary }}</p><div>{{ page_date }}</div><div>{{ page_summary }}</div><div>{{ page_description }}</div>{{ content_html | safe }}{% endblock body %}",
     )
     .expect("post template should be written");
     fs::write(
@@ -589,6 +589,118 @@ fn exposes_frontmatter_metadata_in_page_templates() {
 
     assert!(post.html.contains("2026-03-17"));
     assert!(post.html.contains("Example summary"));
+}
+
+#[test]
+fn page_description_falls_back_to_site_description_and_omits_empty_values() {
+    let dir = tempdir().expect("tempdir should be created");
+    let project_root = dir.path();
+
+    fs::create_dir_all(project_root.join("content")).expect("content dir should be created");
+    fs::write(
+        project_root.join("content/about.md"),
+        "---\ntitle: About\n---\n\n# About",
+    )
+    .expect("page should be written");
+
+    let theme_root = project_root.join("themes/default");
+    fs::create_dir_all(theme_root.join("templates")).expect("templates should be created");
+    fs::create_dir_all(theme_root.join("static")).expect("static should be created");
+
+    fs::write(
+        theme_root.join("templates/base.html"),
+        "<!doctype html><html><head>{% if page_description %}<meta name=\"description\" content=\"{{ page_description }}\">{% endif %}</head><body>{% block body %}{% endblock body %}</body></html>",
+    )
+    .expect("base template should be written");
+    fs::write(
+        theme_root.join("templates/index.html"),
+        "{% extends \"base.html\" %}{% block body %}{{ content_html | safe }}{% endblock body %}",
+    )
+    .expect("index template should be written");
+    fs::write(
+        theme_root.join("templates/page.html"),
+        "{% extends \"base.html\" %}{% block body %}{{ content_html | safe }}{% endblock body %}",
+    )
+    .expect("page template should be written");
+    fs::write(
+        theme_root.join("templates/post.html"),
+        "{% extends \"base.html\" %}{% block body %}{{ content_html | safe }}{% endblock body %}",
+    )
+    .expect("post template should be written");
+    fs::write(
+        theme_root.join("templates/project.html"),
+        "{% extends \"base.html\" %}{% block body %}{{ content_html | safe }}{% endblock body %}",
+    )
+    .expect("project template should be written");
+    fs::write(
+        theme_root.join("templates/section.html"),
+        "{% extends \"base.html\" %}{% block body %}{% endblock body %}",
+    )
+    .expect("section template should be written");
+    fs::write(
+        theme_root.join("theme.toml"),
+        "name = \"default\"\nversion = \"0.1.0\"\nauthor = \"Rustipo\"\ndescription = \"Default\"\n",
+    )
+    .expect("theme metadata should be written");
+
+    let pages = build_pages(project_root.join("content")).expect("pages should build");
+    let theme = load_active_theme(project_root, "default").expect("theme should load");
+    let palette = load_palette(project_root, "default").expect("palette should load");
+
+    let render_with_description = |description: &str| {
+        let config = SiteConfig {
+            title: "My Site".to_string(),
+            base_url: "https://example.com".to_string(),
+            theme: "default".to_string(),
+            palette: None,
+            menus: None,
+            description: description.to_string(),
+            author: None,
+            site: None,
+        };
+        let favicon_links = config
+            .resolve_favicon_links(project_root)
+            .expect("favicon links should resolve");
+        let site_style = config.style_options();
+        let site_has_custom_css = config.has_custom_css(project_root);
+
+        render_pages(
+            &theme,
+            &config,
+            &pages,
+            &SiteRenderContext {
+                favicon_links: &favicon_links,
+                site_style: &site_style,
+                site_has_custom_css,
+                site_font_faces_css: None,
+                asset_version: "test",
+                palette: &palette,
+            },
+        )
+        .expect("pages should render")
+    };
+
+    let rendered = render_with_description("Site fallback description");
+    let about = rendered
+        .iter()
+        .find(|page| page.route == "/about/")
+        .expect("about route should be rendered");
+    assert!(
+        about
+            .html
+            .contains("meta name=\"description\" content=\"Site fallback description\"")
+    );
+
+    let rendered_without_description = render_with_description("");
+    let about_without_description = rendered_without_description
+        .iter()
+        .find(|page| page.route == "/about/")
+        .expect("about route should be rendered");
+    assert!(
+        !about_without_description
+            .html
+            .contains("meta name=\"description\"")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add a shared `page_description` template value with page-summary and site-description fallback
- emit default meta description tags from Atlas, Journal, and the scaffolded default theme
- document the new metadata contract and cover fallback plus empty omission in tests

Closes #146

## Testing
- cargo fmt --all
- cargo test -q
- cargo clippy --all-targets --all-features -- -D warnings
- cargo run -- build (from site/)
