### PR TITLE
feat(deploy): add cloudflare pages workflow helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ MVP complete, active post-MVP development.
 - `rustipo palette use <id>`
 - `rustipo theme install <source>`
 - `rustipo deploy github-pages`
+- `rustipo deploy cloudflare-pages`
 
 ## Installation And Quick Start
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -314,6 +314,37 @@ Current behavior:
 - Workflow runs `rustipo build` and deploys `dist/` using Pages actions
 - Refuses to overwrite existing workflow unless `--force` is provided
 
+## `rustipo deploy cloudflare-pages`
+
+Generates a GitHub Actions workflow for deploying `dist/` to Cloudflare Pages using Wrangler.
+
+Example:
+
+```bash
+rustipo deploy cloudflare-pages
+```
+
+```bash
+rustipo deploy cloudflare-pages --force
+```
+
+Current behavior:
+
+- Writes `.github/workflows/deploy-cloudflare-pages.yml`
+- Workflow installs Rustipo from crates.io with `cargo install rustipo --locked`
+- Workflow runs `rustipo build`
+- Workflow deploys `dist/` with `cloudflare/wrangler-action`
+- Expects these repository settings before the workflow can run:
+  - secret: `CLOUDFLARE_API_TOKEN`
+  - secret: `CLOUDFLARE_ACCOUNT_ID`
+  - variable: `CLOUDFLARE_PAGES_PROJECT`
+- Refuses to overwrite existing workflow unless `--force` is provided
+
+If you prefer Cloudflare Pages Git integration instead of direct uploads, use:
+
+- build command: `cargo install rustipo --locked && rustipo build`
+- build output directory: `dist`
+
 ## Style Options (`config.toml`)
 
 You can control default layout behavior without editing theme CSS:

--- a/docs/implemented-features.md
+++ b/docs/implemented-features.md
@@ -22,6 +22,8 @@
 - `rustipo palette use <id>`
 - `rustipo deploy github-pages`
   - `--force`
+- `rustipo deploy cloudflare-pages`
+  - `--force`
 
 ## Distribution And Release
 

--- a/site/content/reference/cli.md
+++ b/site/content/reference/cli.md
@@ -56,6 +56,21 @@ For the theme and palette model behind those commands, continue to [Themes and p
 
 Generates a GitHub Pages workflow that installs the published `rustipo` binary and runs `rustipo build`.
 
+### `rustipo deploy cloudflare-pages`
+
+Generates a Cloudflare Pages workflow that builds `dist/` and deploys it with Wrangler.
+
+The generated workflow expects:
+
+- `CLOUDFLARE_API_TOKEN`
+- `CLOUDFLARE_ACCOUNT_ID`
+- `CLOUDFLARE_PAGES_PROJECT`
+
+If you prefer Cloudflare Pages Git integration, use:
+
+- build command: `cargo install rustipo --locked && rustipo build`
+- build output directory: `dist`
+
 ## Recommended Local Workflow
 
 ```bash

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -90,13 +90,19 @@ pub enum DeployCommands {
         #[arg(long, default_value_t = false)]
         force: bool,
     },
+    /// Generate Cloudflare Pages deployment workflow
+    CloudflarePages {
+        /// Overwrite existing workflow file if present
+        #[arg(long, default_value_t = false)]
+        force: bool,
+    },
 }
 
 #[cfg(test)]
 mod tests {
     use clap::Parser;
 
-    use super::{Cli, Commands, PaletteCommands};
+    use super::{Cli, Commands, DeployCommands, PaletteCommands};
 
     #[test]
     fn parses_dev_command_with_host_and_port() {
@@ -131,6 +137,19 @@ mod tests {
                 other => panic!("expected palette use command, got {other:?}"),
             },
             other => panic!("expected palette command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_deploy_cloudflare_pages_command() {
+        let cli = Cli::parse_from(["rustipo", "deploy", "cloudflare-pages", "--force"]);
+
+        match cli.command {
+            Commands::Deploy { command } => match command {
+                DeployCommands::CloudflarePages { force } => assert!(force),
+                other => panic!("expected cloudflare-pages deploy command, got {other:?}"),
+            },
+            other => panic!("expected deploy command, got {other:?}"),
         }
     }
 }

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -55,8 +55,70 @@ jobs:
         uses: actions/deploy-pages@v4
 "#;
 
+const CLOUDFLARE_PAGES_WORKFLOW: &str = r#"name: Deploy Cloudflare Pages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cloudflare-pages
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Rustipo
+        run: cargo install rustipo --locked
+
+      - name: Build Site
+        run: rustipo build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          command: pages deploy dist --project-name=${{ vars.CLOUDFLARE_PAGES_PROJECT }}
+"#;
+
 pub fn github_pages(force: bool) -> Result<()> {
     let workflow_path = Path::new(".github/workflows/deploy-pages.yml");
+    write_workflow_file(workflow_path, GITHUB_PAGES_WORKFLOW, force)?;
+
+    println!("Created GitHub Pages workflow: {}", workflow_path.display());
+    println!("Next: push to master, then enable Pages in repository settings.");
+    Ok(())
+}
+
+pub fn cloudflare_pages(force: bool) -> Result<()> {
+    let workflow_path = Path::new(".github/workflows/deploy-cloudflare-pages.yml");
+    write_workflow_file(workflow_path, CLOUDFLARE_PAGES_WORKFLOW, force)?;
+
+    println!(
+        "Created Cloudflare Pages workflow: {}",
+        workflow_path.display()
+    );
+    println!("Next: create a Cloudflare Pages project, then add these repository settings:");
+    println!("- secret: CLOUDFLARE_API_TOKEN");
+    println!("- secret: CLOUDFLARE_ACCOUNT_ID");
+    println!("- variable: CLOUDFLARE_PAGES_PROJECT");
+    Ok(())
+}
+
+fn write_workflow_file(workflow_path: &Path, content: &str, force: bool) -> Result<()> {
     if workflow_path.exists() && !force {
         bail!(
             "workflow already exists: {} (use --force to overwrite)",
@@ -69,10 +131,8 @@ pub fn github_pages(force: bool) -> Result<()> {
         .context("failed to resolve workflow parent directory")?;
     fs::create_dir_all(parent)
         .with_context(|| format!("failed to create workflow directory: {}", parent.display()))?;
-    fs::write(workflow_path, GITHUB_PAGES_WORKFLOW)
+    fs::write(workflow_path, content)
         .with_context(|| format!("failed to write workflow file: {}", workflow_path.display()))?;
 
-    println!("Created GitHub Pages workflow: {}", workflow_path.display());
-    println!("Next: push to master, then enable Pages in repository settings.");
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,9 @@ fn main() -> Result<()> {
         },
         cli::Commands::Deploy { command } => match command {
             cli::DeployCommands::GithubPages { force } => commands::deploy::github_pages(force),
+            cli::DeployCommands::CloudflarePages { force } => {
+                commands::deploy::cloudflare_pages(force)
+            }
         },
     }
 }

--- a/tests/cli_flow.rs
+++ b/tests/cli_flow.rs
@@ -703,6 +703,59 @@ fn deploy_github_pages_refuses_overwrite_without_force() {
 }
 
 #[test]
+fn deploy_cloudflare_pages_generates_workflow_file() {
+    let dir = tempdir().expect("tempdir should be created");
+    let root = dir.path();
+
+    let output = run_cli(root, &["deploy", "cloudflare-pages"]);
+    assert!(
+        output.status.success(),
+        "deploy helper failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let workflow = root.join(".github/workflows/deploy-cloudflare-pages.yml");
+    assert!(workflow.is_file());
+    let content = fs::read_to_string(workflow).expect("workflow should be readable");
+    assert!(content.contains("name: Deploy Cloudflare Pages"));
+    assert!(content.contains("cloudflare/wrangler-action@v3"));
+    assert!(content.contains("command: pages deploy dist"));
+    assert!(content.contains("CLOUDFLARE_API_TOKEN"));
+    assert!(content.contains("CLOUDFLARE_ACCOUNT_ID"));
+    assert!(content.contains("CLOUDFLARE_PAGES_PROJECT"));
+    assert!(content.contains("cargo install rustipo --locked"));
+    assert!(content.contains("run: rustipo build"));
+}
+
+#[test]
+fn deploy_cloudflare_pages_refuses_overwrite_without_force() {
+    let dir = tempdir().expect("tempdir should be created");
+    let root = dir.path();
+
+    fs::create_dir_all(root.join(".github/workflows")).expect("workflow dir should be created");
+    fs::write(
+        root.join(".github/workflows/deploy-cloudflare-pages.yml"),
+        "name: existing",
+    )
+    .expect("existing workflow should be written");
+
+    let output = run_cli(root, &["deploy", "cloudflare-pages"]);
+    assert!(
+        !output.status.success(),
+        "deploy helper should fail without --force"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("workflow already exists"));
+
+    let force_output = run_cli(root, &["deploy", "cloudflare-pages", "--force"]);
+    assert!(
+        force_output.status.success(),
+        "deploy helper should overwrite with --force: {}",
+        String::from_utf8_lossy(&force_output.stderr)
+    );
+}
+
+#[test]
 fn bundled_examples_build_successfully() {
     let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let examples_root = repo_root.join("examples");


### PR DESCRIPTION
## Summary
- add `rustipo deploy cloudflare-pages` to generate a Cloudflare Pages deployment workflow
- document the required Cloudflare secrets and project variable
- cover workflow generation and overwrite behavior in CLI tests

Closes #153

## Testing
- cargo fmt --all
- cargo test -q
- cargo clippy --all-targets --all-features -- -D warnings
- cargo run --manifest-path /Users/fcen/projects/rustipo/Cargo.toml -- deploy cloudflare-pages
