### PR TITLE
feat(deploy): add netlify workflow helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ MVP complete, active post-MVP development.
 - `rustipo theme install <source>`
 - `rustipo deploy github-pages`
 - `rustipo deploy cloudflare-pages`
+- `rustipo deploy netlify`
 
 ## Installation And Quick Start
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -345,6 +345,32 @@ If you prefer Cloudflare Pages Git integration instead of direct uploads, use:
 - build command: `cargo install rustipo --locked && rustipo build`
 - build output directory: `dist`
 
+## `rustipo deploy netlify`
+
+Generates a GitHub Actions workflow for deploying `dist/` to Netlify with Netlify CLI.
+
+Example:
+
+```bash
+rustipo deploy netlify
+```
+
+```bash
+rustipo deploy netlify --force
+```
+
+Current behavior:
+
+- Writes `.github/workflows/deploy-netlify.yml`
+- Workflow installs Rustipo from crates.io with `cargo install rustipo --locked`
+- Workflow installs Netlify CLI with `npm install -g netlify-cli`
+- Workflow runs `rustipo build`
+- Workflow deploys `dist/` with `netlify deploy --dir=dist --prod`
+- Expects these repository secrets before the workflow can run:
+  - `NETLIFY_AUTH_TOKEN`
+  - `NETLIFY_SITE_ID`
+- Refuses to overwrite existing workflow unless `--force` is provided
+
 ## Style Options (`config.toml`)
 
 You can control default layout behavior without editing theme CSS:

--- a/docs/implemented-features.md
+++ b/docs/implemented-features.md
@@ -24,6 +24,8 @@
   - `--force`
 - `rustipo deploy cloudflare-pages`
   - `--force`
+- `rustipo deploy netlify`
+  - `--force`
 
 ## Distribution And Release
 

--- a/site/content/reference/cli.md
+++ b/site/content/reference/cli.md
@@ -71,6 +71,15 @@ If you prefer Cloudflare Pages Git integration, use:
 - build command: `cargo install rustipo --locked && rustipo build`
 - build output directory: `dist`
 
+### `rustipo deploy netlify`
+
+Generates a Netlify deployment workflow that installs Rustipo, builds `dist/`, and deploys it with Netlify CLI.
+
+The generated workflow expects:
+
+- `NETLIFY_AUTH_TOKEN`
+- `NETLIFY_SITE_ID`
+
 ## Recommended Local Workflow
 
 ```bash

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -96,6 +96,12 @@ pub enum DeployCommands {
         #[arg(long, default_value_t = false)]
         force: bool,
     },
+    /// Generate Netlify deployment workflow
+    Netlify {
+        /// Overwrite existing workflow file if present
+        #[arg(long, default_value_t = false)]
+        force: bool,
+    },
 }
 
 #[cfg(test)]
@@ -148,6 +154,19 @@ mod tests {
             Commands::Deploy { command } => match command {
                 DeployCommands::CloudflarePages { force } => assert!(force),
                 other => panic!("expected cloudflare-pages deploy command, got {other:?}"),
+            },
+            other => panic!("expected deploy command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_deploy_netlify_command() {
+        let cli = Cli::parse_from(["rustipo", "deploy", "netlify", "--force"]);
+
+        match cli.command {
+            Commands::Deploy { command } => match command {
+                DeployCommands::Netlify { force } => assert!(force),
+                other => panic!("expected netlify deploy command, got {other:?}"),
             },
             other => panic!("expected deploy command, got {other:?}"),
         }

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -94,6 +94,51 @@ jobs:
           command: pages deploy dist --project-name=${{ vars.CLOUDFLARE_PAGES_PROJECT }}
 "#;
 
+const NETLIFY_WORKFLOW: &str = r#"name: Deploy Netlify
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: netlify
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Rustipo
+        run: cargo install rustipo --locked
+
+      - name: Build Site
+        run: rustipo build
+
+      - name: Install Netlify CLI
+        run: npm install -g netlify-cli
+
+      - name: Deploy to Netlify
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        run: netlify deploy --dir=dist --prod
+"#;
+
 pub fn github_pages(force: bool) -> Result<()> {
     let workflow_path = Path::new(".github/workflows/deploy-pages.yml");
     write_workflow_file(workflow_path, GITHUB_PAGES_WORKFLOW, force)?;
@@ -115,6 +160,17 @@ pub fn cloudflare_pages(force: bool) -> Result<()> {
     println!("- secret: CLOUDFLARE_API_TOKEN");
     println!("- secret: CLOUDFLARE_ACCOUNT_ID");
     println!("- variable: CLOUDFLARE_PAGES_PROJECT");
+    Ok(())
+}
+
+pub fn netlify(force: bool) -> Result<()> {
+    let workflow_path = Path::new(".github/workflows/deploy-netlify.yml");
+    write_workflow_file(workflow_path, NETLIFY_WORKFLOW, force)?;
+
+    println!("Created Netlify workflow: {}", workflow_path.display());
+    println!("Next: connect or create your Netlify site, then add these repository secrets:");
+    println!("- secret: NETLIFY_AUTH_TOKEN");
+    println!("- secret: NETLIFY_SITE_ID");
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ fn main() -> Result<()> {
             cli::DeployCommands::CloudflarePages { force } => {
                 commands::deploy::cloudflare_pages(force)
             }
+            cli::DeployCommands::Netlify { force } => commands::deploy::netlify(force),
         },
     }
 }

--- a/tests/cli_flow.rs
+++ b/tests/cli_flow.rs
@@ -756,6 +756,60 @@ fn deploy_cloudflare_pages_refuses_overwrite_without_force() {
 }
 
 #[test]
+fn deploy_netlify_generates_workflow_file() {
+    let dir = tempdir().expect("tempdir should be created");
+    let root = dir.path();
+
+    let output = run_cli(root, &["deploy", "netlify"]);
+    assert!(
+        output.status.success(),
+        "deploy helper failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let workflow = root.join(".github/workflows/deploy-netlify.yml");
+    assert!(workflow.is_file());
+    let content = fs::read_to_string(workflow).expect("workflow should be readable");
+    assert!(content.contains("name: Deploy Netlify"));
+    assert!(content.contains("actions/setup-node@v6"));
+    assert!(content.contains("node-version: 22"));
+    assert!(content.contains("npm install -g netlify-cli"));
+    assert!(content.contains("netlify deploy --dir=dist --prod"));
+    assert!(content.contains("NETLIFY_AUTH_TOKEN"));
+    assert!(content.contains("NETLIFY_SITE_ID"));
+    assert!(content.contains("cargo install rustipo --locked"));
+    assert!(content.contains("run: rustipo build"));
+}
+
+#[test]
+fn deploy_netlify_refuses_overwrite_without_force() {
+    let dir = tempdir().expect("tempdir should be created");
+    let root = dir.path();
+
+    fs::create_dir_all(root.join(".github/workflows")).expect("workflow dir should be created");
+    fs::write(
+        root.join(".github/workflows/deploy-netlify.yml"),
+        "name: existing",
+    )
+    .expect("existing workflow should be written");
+
+    let output = run_cli(root, &["deploy", "netlify"]);
+    assert!(
+        !output.status.success(),
+        "deploy helper should fail without --force"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("workflow already exists"));
+
+    let force_output = run_cli(root, &["deploy", "netlify", "--force"]);
+    assert!(
+        force_output.status.success(),
+        "deploy helper should overwrite with --force: {}",
+        String::from_utf8_lossy(&force_output.stderr)
+    );
+}
+
+#[test]
 fn bundled_examples_build_successfully() {
     let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let examples_root = repo_root.join("examples");


### PR DESCRIPTION
## Summary
- add `rustipo deploy netlify`
- generate a GitHub Actions workflow that builds with Rustipo and deploys `dist/` with Netlify CLI
- document the required Netlify secrets and cover workflow generation in CLI tests

Closes #152

## Verification
- cargo fmt --all
- cargo test -q
- cargo clippy --all-targets --all-features -- -D warnings
- cargo run --quiet --manifest-path /Users/fcen/projects/rustipo/Cargo.toml -- deploy netlify