### PR TITLE
docs(roadmap): clarify release train sequencing

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -66,6 +66,12 @@ For historical post-MVP batch planning, see:
 
 ## Upcoming milestones
 
+Current release-train note:
+
+- the next published Rustipo release is still expected to be `0.12.0`
+- some hosting and metadata work originally grouped under `v0.13.0` has already landed on `master`
+- milestone labels are used for planning themes and can drift from the next crate version when upstream blockers delay a batch
+
 - `v0.12.0`: maintenance and workflow compatibility
   - audit GitHub Actions workflows for Node 24 compatibility
 - `v0.13.0`: hosting and metadata polish

--- a/site/content/roadmap.md
+++ b/site/content/roadmap.md
@@ -59,6 +59,12 @@ Maintenance and workflow compatibility:
 
 - audit GitHub Actions workflows for Node 24 compatibility
 
+Release-train note:
+
+- the next published Rustipo release is still expected to be `0.12.0`
+- some hosting and metadata work originally grouped under `v0.13.0` is already merged on `master`
+- milestone labels are planning buckets, so they can drift from the next crate version when a blocked item holds the release train
+
 ## After That: `v0.13.0`
 
 Hosting and metadata polish:


### PR DESCRIPTION
## Summary
- explain that the next published release is still expected to be `0.12.0`
- note that some work grouped under `v0.13.0` is already merged on `master`
- keep the public roadmap aligned with the current release train

## Verification
- cargo run -- build