### PR TITLE
docs(roadmap): reflect v0.12.0 release state

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,6 +22,7 @@ Current shipped post-MVP capabilities:
 - completed `v0.9.0` publishing and site structure release
 - completed `v0.10.0` product identity and examples release
 - completed `v0.11.0` distribution and docs release
+- completed `v0.12.0` docs polish and deployment release
 - flagship example sites for blog and docs-style use cases
 - built-in `atlas` and `journal` layout themes
 - generated publishing/search artifacts during build:
@@ -63,24 +64,22 @@ For historical post-MVP batch planning, see:
 - `v0.11.0`: distribution and docs
   - docs site built with Rustipo and published with GitHub Pages
   - prebuilt binaries
+- `v0.12.0`: docs polish and deployment
+  - docs-site visual and subpath fixes
+  - built-in default meta descriptions
+  - Cloudflare Pages deployment helper
+  - Netlify deployment helper
 
 ## Upcoming milestones
 
-Current release-train note:
-
-- the next published Rustipo release is still expected to be `0.12.0`
-- some hosting and metadata work originally grouped under `v0.13.0` has already landed on `master`
-- milestone labels are used for planning themes and can drift from the next crate version when upstream blockers delay a batch
-
-- `v0.12.0`: maintenance and workflow compatibility
-  - audit GitHub Actions workflows for Node 24 compatibility
-- `v0.13.0`: hosting and metadata polish
-  - built-in default meta description support for themes
-  - Cloudflare Pages deployment support
-  - Netlify deployment support
 - `v0.14.0`: rich content and media
   - reusable embeds or shortcodes for interactive content
   - built-in image processing and resize helpers
+
+Tracked maintenance follow-up:
+
+- audit GitHub Actions workflows for Node 24 compatibility
+  - kept separate because the remaining warning is blocked on upstream action updates
 
 ## Milestone 1: Foundation
 

--- a/site/content/roadmap.md
+++ b/site/content/roadmap.md
@@ -5,7 +5,7 @@ summary: Recent Rustipo releases and the next planned milestone batches for Rust
 
 # Roadmap
 
-Rustipo has shipped five post-MVP releases in a row, each focused on a clear product slice.
+Rustipo has shipped six post-MVP releases in a row, each focused on a clear product slice.
 
 ## Recent Releases
 
@@ -53,32 +53,28 @@ Distribution and docs release:
 - docs site with Rustipo
 - prebuilt release binaries
 
-## Next Up: `v0.12.0`
+## `v0.12.0`
 
-Maintenance and workflow compatibility:
+Docs polish and deployment:
 
-- audit GitHub Actions workflows for Node 24 compatibility
-
-Release-train note:
-
-- the next published Rustipo release is still expected to be `0.12.0`
-- some hosting and metadata work originally grouped under `v0.13.0` is already merged on `master`
-- milestone labels are planning buckets, so they can drift from the next crate version when a blocked item holds the release train
-
-## After That: `v0.13.0`
-
-Hosting and metadata polish:
-
-- built-in default meta description support for themes
+- docs-site visual and subpath fixes
+- built-in default meta descriptions
 - Cloudflare Pages deployment support
 - Netlify deployment support
 
-## Looking Ahead: `v0.14.0`
+## Next Up: `v0.14.0`
 
 Rich content and media:
 
 - reusable embeds or shortcodes for interactive content
 - built-in image processing and resize helpers
+
+## Tracked Follow-up
+
+Maintenance and workflow compatibility:
+
+- audit GitHub Actions workflows for Node 24 compatibility
+- this is still open because the remaining warning is blocked on upstream GitHub Action updates rather than Rustipo code changes
 
 ## Later
 


### PR DESCRIPTION
## Summary
- mark `v0.12.0` as shipped in the public roadmap
- move the remaining Node 24 work into a tracked follow-up instead of an open release bucket
- align the site roadmap wording with the current issue and milestone state

## Verification
- cargo run -- build