### PR TITLE
docs(roadmap): define v0.15.0 batch

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -70,11 +70,18 @@ For historical post-MVP batch planning, see:
   - Cloudflare Pages deployment helper
   - Netlify deployment helper
 
-## Upcoming milestones
+## Completed upcoming batch work
 
 - `v0.14.0`: rich content and media
   - reusable embeds or shortcodes for interactive content
   - built-in image processing and resize helpers
+
+## Upcoming milestones
+
+- `v0.15.0`: ecosystem consistency and reusable site conventions
+  - formalize and expand taxonomy support
+  - formalize the canonical palette token contract
+  - optional analytics integration
 
 Tracked maintenance follow-up:
 

--- a/site/content/roadmap.md
+++ b/site/content/roadmap.md
@@ -62,12 +62,22 @@ Docs polish and deployment:
 - Cloudflare Pages deployment support
 - Netlify deployment support
 
-## Next Up: `v0.14.0`
+## Completed Upcoming Batch Work
+
+### `v0.14.0`
 
 Rich content and media:
 
 - reusable embeds or shortcodes for interactive content
 - built-in image processing and resize helpers
+
+## Next Up: `v0.15.0`
+
+Ecosystem consistency and reusable site conventions:
+
+- expanded taxonomy support
+- formalized palette token contract
+- optional analytics integration
 
 ## Tracked Follow-up
 
@@ -78,9 +88,6 @@ Maintenance and workflow compatibility:
 
 ## Later
 
-- optional analytics integration
-- expanded taxonomy support
-- formalized palette token contract
 - optional SCSS support
 - multilingual site support
 


### PR DESCRIPTION
## Summary
- mark the completed `v0.14.0` batch as done in the roadmap docs
- define `v0.15.0` as the next roadmap batch
- align the public roadmap with the GitHub milestone assignments

Refs #82