### PR TITLE
feat(config): add optional analytics integration

### DIFF
--- a/assets/themes/atlas/templates/partials/head_assets.html
+++ b/assets/themes/atlas/templates/partials/head_assets.html
@@ -19,6 +19,9 @@
   {{ site_font_faces_css | safe }}
 </style>
 {% endif %}
+{% if site_analytics_head_html %}
+{{ site_analytics_head_html | safe }}
+{% endif %}
 <link rel="stylesheet" href="{{ asset_url(path='style.css') }}?v={{ site_asset_version }}" />
 <link rel="stylesheet" href="{{ asset_url(path='palette.css') }}?v={{ site_asset_version }}" />
 {% if site_has_custom_css %}

--- a/assets/themes/journal/templates/partials/head_assets.html
+++ b/assets/themes/journal/templates/partials/head_assets.html
@@ -19,6 +19,9 @@
   {{ site_font_faces_css | safe }}
 </style>
 {% endif %}
+{% if site_analytics_head_html %}
+{{ site_analytics_head_html | safe }}
+{% endif %}
 <link rel="stylesheet" href="{{ asset_url(path='style.css') }}?v={{ site_asset_version }}" />
 <link rel="stylesheet" href="{{ asset_url(path='palette.css') }}?v={{ site_asset_version }}" />
 {% if site_has_custom_css %}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -49,6 +49,18 @@ Project validation:
 rustipo check
 ```
 
+Analytics configuration is opt-in. For the first built-in integration, Rustipo supports Plausible
+with an optional self-hosted script override:
+
+```toml
+[site.analytics.plausible]
+domain = "docs.example.com"
+# Optional for self-hosted Plausible:
+# script_src = "https://stats.example.com/js/script.js"
+```
+
+Built-in themes render the analytics snippet automatically when configured.
+
 Theme discovery:
 
 ```bash
@@ -155,6 +167,7 @@ Current behavior:
   - `site.typography.heading_font`
   - `site.typography.mono_font`
 - Exposes `site_font_faces_css` to templates for optional font-face injection
+- Exposes `site_analytics_head_html` to templates for opt-in analytics snippet output
 - Auto-includes `static/custom.css` in template context when present (`site_has_custom_css`)
 - Writes rendered pages to `dist/` using pretty URL output paths
 - Writes generated palette variables to `dist/palette.css`

--- a/docs/implemented-features.md
+++ b/docs/implemented-features.md
@@ -232,6 +232,7 @@
 - `site_favicon_ico`
 - `site_apple_touch_icon`
 - `site_asset_version`
+- `site_analytics_head_html`
 - `site_style`
   - `content_width`
   - `top_gap`
@@ -269,6 +270,8 @@
 - resolution order:
   - `page_summary`
   - `site_description`
+- opt-in Plausible analytics snippet support in built-in themes
+- optional self-hosted Plausible `script_src` override
 - `route`
 - `section_name`
 - `section_title`

--- a/docs/theme-contract.md
+++ b/docs/theme-contract.md
@@ -198,6 +198,7 @@ Rustipo injects common site variables into template contexts, including:
   - `next_url`
 - favicon helpers: `site_favicon`, `site_favicon_svg`, `site_favicon_ico`, `site_apple_touch_icon`
 - asset helper: `site_asset_version` (stable cache-busting fingerprint for generated asset URLs)
+- analytics helper: `site_analytics_head_html` (optional provider-agnostic head snippet for configured analytics)
 - style helpers from config:
   - `site_style.content_width`
   - `site_style.top_gap`
@@ -215,6 +216,25 @@ Rustipo injects common site variables into template contexts, including:
 - `site_description`
 
 If both values are empty, Rustipo leaves `page_description` unset so themes can omit the tag cleanly.
+
+`site_analytics_head_html` is the stable hook for built-in analytics integrations. In `v0.15`,
+Rustipo supports opt-in Plausible analytics via:
+
+```toml
+[site.analytics.plausible]
+domain = "docs.example.com"
+# Optional for self-hosted Plausible:
+# script_src = "https://stats.example.com/js/script.js"
+```
+
+When present, Rustipo renders a ready-to-include head snippet. Themes can inherit the built-in
+head partial behavior or explicitly render:
+
+```html
+{% if site_analytics_head_html %}
+{{ site_analytics_head_html | safe }}
+{% endif %}
+```
 
 Rustipo also registers small Tera helpers for theme authors:
 

--- a/docs/theme-tera.md
+++ b/docs/theme-tera.md
@@ -78,6 +78,7 @@ Rustipo injects common values such as:
 - `site_title`
 - `site_description`
 - `site_asset_version`
+- `site_analytics_head_html`
 - `site_taxonomies`
 - `site_style.*`
 
@@ -87,6 +88,19 @@ Rustipo injects common values such as:
 - `site_description`
 
 If both are empty, `page_description` is omitted.
+
+`site_analytics_head_html` is the stable convenience value for built-in analytics output. In
+`v0.15`, Rustipo supports opt-in Plausible configuration from `config.toml`:
+
+```toml
+[site.analytics.plausible]
+domain = "docs.example.com"
+# Optional for self-hosted Plausible:
+# script_src = "https://stats.example.com/js/script.js"
+```
+
+When configured, `site_analytics_head_html` contains a ready-to-render `<script defer ...>`
+snippet. Built-in themes already include it in their shared head partials.
 
 Rustipo also injects stable navigation and page-state values:
 

--- a/site/content/reference/cli.md
+++ b/site/content/reference/cli.md
@@ -8,6 +8,21 @@ order: 1
 
 Rustipo currently centers on a small CLI surface that covers the full authoring loop.
 
+## Config-Driven Extras
+
+### Analytics
+
+Rustipo supports opt-in Plausible analytics from `config.toml`:
+
+```toml
+[site.analytics.plausible]
+domain = "docs.example.com"
+# Optional for self-hosted Plausible:
+# script_src = "https://stats.example.com/js/script.js"
+```
+
+Built-in themes render that snippet automatically through their shared head partials.
+
 ## Core Commands
 
 ### `rustipo new <site-name>`

--- a/src/commands/new/scaffold.rs
+++ b/src/commands/new/scaffold.rs
@@ -107,6 +107,9 @@ pub const HEAD_ASSETS_PARTIAL: &str = r#"{% if site_favicon_svg %}<link rel="ico
   {{ site_font_faces_css | safe }}
 </style>
 {% endif %}
+{% if site_analytics_head_html %}
+{{ site_analytics_head_html | safe }}
+{% endif %}
 <link rel="stylesheet" href="{{ asset_url(path='style.css') }}?v={{ site_asset_version }}" />
 <link rel="stylesheet" href="{{ asset_url(path='palette.css') }}?v={{ site_asset_version }}" />
 {% if site_has_custom_css %}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -44,8 +44,20 @@ pub struct AuthorConfig {
 pub struct SiteOptions {
     pub posts_per_page: Option<usize>,
     pub favicon: Option<String>,
+    pub analytics: Option<AnalyticsOptions>,
     pub layout: Option<LayoutOptions>,
     pub typography: Option<TypographyOptions>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct AnalyticsOptions {
+    pub plausible: Option<PlausibleAnalyticsOptions>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct PlausibleAnalyticsOptions {
+    pub domain: String,
+    pub script_src: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -165,6 +177,31 @@ impl SiteConfig {
         let _ = self;
         project_root.as_ref().join("static/custom.css").is_file()
     }
+
+    pub fn analytics_head_html(&self) -> Option<String> {
+        let analytics = self
+            .site
+            .as_ref()
+            .and_then(|site| site.analytics.as_ref())?;
+        let plausible = analytics.plausible.as_ref()?;
+        let domain = plausible.domain.trim();
+        if domain.is_empty() {
+            return None;
+        }
+
+        let script_src = plausible
+            .script_src
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("https://plausible.io/js/script.js");
+
+        Some(format!(
+            "<script defer data-domain=\"{}\" src=\"{}\"></script>",
+            escape_html_attr(domain),
+            escape_html_attr(script_src)
+        ))
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize)]
@@ -229,6 +266,12 @@ pub fn load(path: impl AsRef<Path>) -> Result<SiteConfig> {
             path.display()
         )
     })?;
+    validate_analytics(&config).map_err(|error| {
+        anyhow!(
+            "invalid analytics configuration in config file: {}: {error}",
+            path.display()
+        )
+    })?;
 
     Ok(config)
 }
@@ -260,13 +303,59 @@ fn validate_menus(config: &SiteConfig) -> Result<()> {
     Ok(())
 }
 
+fn validate_analytics(config: &SiteConfig) -> Result<()> {
+    let Some(analytics) = config
+        .site
+        .as_ref()
+        .and_then(|site| site.analytics.as_ref())
+    else {
+        return Ok(());
+    };
+
+    if let Some(plausible) = &analytics.plausible {
+        if plausible.domain.trim().is_empty() {
+            bail!("site.analytics.plausible.domain must not be empty");
+        }
+
+        if plausible
+            .script_src
+            .as_deref()
+            .is_some_and(|value| value.trim().is_empty())
+        {
+            bail!("site.analytics.plausible.script_src must not be empty");
+        }
+    }
+
+    Ok(())
+}
+
+fn escape_html_attr(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+
+    for ch in value.chars() {
+        match ch {
+            '&' => escaped.push_str("&amp;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&#39;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            _ => escaped.push(ch),
+        }
+    }
+
+    escaped
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;
 
     use tempfile::tempdir;
 
-    use super::{LayoutOptions, SiteConfig, SiteOptions, TypographyOptions, load};
+    use super::{
+        AnalyticsOptions, LayoutOptions, PlausibleAnalyticsOptions, SiteConfig, SiteOptions,
+        TypographyOptions, load,
+    };
 
     fn base_config() -> SiteConfig {
         SiteConfig {
@@ -307,6 +396,7 @@ mod tests {
         config.site = Some(SiteOptions {
             posts_per_page: None,
             favicon: Some("/favicon.ico".to_string()),
+            analytics: None,
             layout: None,
             typography: None,
         });
@@ -354,6 +444,7 @@ mod tests {
         config.site = Some(SiteOptions {
             posts_per_page: None,
             favicon: None,
+            analytics: None,
             layout: Some(LayoutOptions {
                 content_width: Some("98%".to_string()),
                 top_gap: Some("3rem".to_string()),
@@ -395,6 +486,66 @@ mod tests {
         fs::write(dir.path().join("static/custom.css"), "body{}")
             .expect("custom css should be written");
         assert!(config.has_custom_css(dir.path()));
+    }
+
+    #[test]
+    fn loads_plausible_analytics_from_config() {
+        let dir = tempdir().expect("tempdir should be created");
+        let config_path = dir.path().join("config.toml");
+        fs::write(
+            &config_path,
+            r#"
+title = "Rustipo"
+base_url = "https://example.com"
+theme = "default"
+description = "Example"
+
+[site.analytics.plausible]
+domain = "docs.example.com"
+"#,
+        )
+        .expect("config should be written");
+
+        let config = load(&config_path).expect("config should load");
+        let analytics = config
+            .site
+            .as_ref()
+            .and_then(|site| site.analytics.as_ref())
+            .and_then(|analytics| analytics.plausible.as_ref())
+            .expect("plausible analytics should be present");
+
+        assert_eq!(analytics.domain, "docs.example.com");
+        assert_eq!(analytics.script_src, None);
+        assert_eq!(
+            config.analytics_head_html().as_deref(),
+            Some(
+                "<script defer data-domain=\"docs.example.com\" src=\"https://plausible.io/js/script.js\"></script>"
+            )
+        );
+    }
+
+    #[test]
+    fn uses_custom_plausible_script_src_when_present() {
+        let mut config = base_config();
+        config.site = Some(SiteOptions {
+            posts_per_page: None,
+            favicon: None,
+            analytics: Some(AnalyticsOptions {
+                plausible: Some(PlausibleAnalyticsOptions {
+                    domain: "docs.example.com".to_string(),
+                    script_src: Some("https://stats.example.com/js/script.js".to_string()),
+                }),
+            }),
+            layout: None,
+            typography: None,
+        });
+
+        assert_eq!(
+            config.analytics_head_html().as_deref(),
+            Some(
+                "<script defer data-domain=\"docs.example.com\" src=\"https://stats.example.com/js/script.js\"></script>"
+            )
+        );
     }
 
     #[test]
@@ -455,6 +606,33 @@ main = [
             error
                 .to_string()
                 .contains("menu 'main' item 1 title must not be empty"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn rejects_blank_plausible_domain() {
+        let dir = tempdir().expect("tempdir should be created");
+        let config_path = dir.path().join("config.toml");
+        fs::write(
+            &config_path,
+            r#"
+title = "Rustipo"
+base_url = "https://example.com"
+theme = "default"
+description = "Example"
+
+[site.analytics.plausible]
+domain = "   "
+"#,
+        )
+        .expect("config should be written");
+
+        let error = load(&config_path).expect_err("blank plausible domain should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("site.analytics.plausible.domain must not be empty"),
             "unexpected error: {error}"
         );
     }

--- a/src/render/templates/mod.rs
+++ b/src/render/templates/mod.rs
@@ -160,6 +160,7 @@ fn insert_common_site_context(
         &render_context.site.site_font_faces_css,
     );
     context.insert("site_asset_version", &render_context.site.asset_version);
+    context.insert("site_analytics_head_html", &config.analytics_head_html());
     context::insert_page_context(
         context,
         config,

--- a/src/render/templates/tests.rs
+++ b/src/render/templates/tests.rs
@@ -393,6 +393,7 @@ fn paginates_blog_section_when_posts_exceed_page_size() {
         site: Some(crate::config::SiteOptions {
             posts_per_page: Some(2),
             favicon: None,
+            analytics: None,
             layout: None,
             typography: None,
         }),
@@ -809,6 +810,103 @@ fn page_description_falls_back_to_site_description_and_omits_empty_values() {
         !about_without_description
             .html
             .contains("meta name=\"description\"")
+    );
+}
+
+#[test]
+fn analytics_head_html_is_available_to_templates_when_plausible_is_configured() {
+    let dir = tempdir().expect("tempdir should be created");
+    let project_root = dir.path();
+
+    fs::create_dir_all(project_root.join("content")).expect("content dir should be created");
+    fs::write(project_root.join("content/index.md"), "# Welcome").expect("index should be written");
+
+    let theme_root = project_root.join("themes/default");
+    fs::create_dir_all(theme_root.join("templates")).expect("templates should be created");
+    fs::create_dir_all(theme_root.join("static")).expect("static should be created");
+
+    fs::write(
+        theme_root.join("templates/base.html"),
+        "<!doctype html><html><head>{% if site_analytics_head_html %}{{ site_analytics_head_html | safe }}{% endif %}</head><body>{% block body %}{% endblock body %}</body></html>",
+    )
+    .expect("base template should be written");
+    for template in [
+        "index.html",
+        "page.html",
+        "post.html",
+        "project.html",
+        "section.html",
+    ] {
+        fs::write(
+            theme_root.join("templates").join(template),
+            "{% extends \"base.html\" %}{% block body %}{{ content_html | safe }}{% endblock body %}",
+        )
+        .expect("template should be written");
+    }
+    fs::write(
+        theme_root.join("theme.toml"),
+        "name = \"default\"\nversion = \"0.1.0\"\nauthor = \"Rustipo\"\ndescription = \"Default\"\n",
+    )
+    .expect("theme metadata should be written");
+
+    let config = SiteConfig {
+        title: "My Site".to_string(),
+        base_url: "https://example.com".to_string(),
+        theme: "default".to_string(),
+        palette: None,
+        menus: None,
+        description: "A site".to_string(),
+        author: None,
+        site: Some(crate::config::SiteOptions {
+            posts_per_page: None,
+            favicon: None,
+            analytics: Some(crate::config::AnalyticsOptions {
+                plausible: Some(crate::config::PlausibleAnalyticsOptions {
+                    domain: "docs.example.com".to_string(),
+                    script_src: Some("https://stats.example.com/js/script.js".to_string()),
+                }),
+            }),
+            layout: None,
+            typography: None,
+        }),
+    };
+
+    let pages = build_pages(project_root.join("content")).expect("pages should build");
+    let theme = load_active_theme(project_root, "default").expect("theme should load");
+    let favicon_links = config
+        .resolve_favicon_links(project_root)
+        .expect("favicon links should resolve");
+    let site_style = config.style_options();
+    let site_has_custom_css = config.has_custom_css(project_root);
+    let palette =
+        load_palette(project_root, config.selected_palette()).expect("palette should load");
+
+    let rendered = render_pages(
+        &theme,
+        &config,
+        &pages,
+        &SiteRenderContext {
+            favicon_links: &favicon_links,
+            site_style: &site_style,
+            site_has_custom_css,
+            site_font_faces_css: None,
+            asset_version: "test",
+            palette: &palette,
+        },
+    )
+    .expect("pages should render");
+
+    let index = rendered
+        .iter()
+        .find(|page| page.route == "/")
+        .expect("index route should render");
+
+    assert!(
+        index
+            .html
+            .contains("<script defer data-domain=\"docs.example.com\" src=\"https://stats.example.com/js/script.js\"></script>"),
+        "expected analytics snippet in rendered head: {}",
+        index.html
     );
 }
 


### PR DESCRIPTION
## Summary
- add opt-in Plausible analytics configuration under `[site.analytics.plausible]`
- expose a provider-agnostic `site_analytics_head_html` hook to templates and render it in built-in themes and the scaffold
- document the config model and cover config parsing plus rendered output with tests

## Verification
- cargo fmt --all
- cargo test -q
- cargo clippy --all-targets --all-features -- -D warnings
- cargo run --quiet -- build (from `site/`)
