### PR TITLE
docs(roadmap): define v0.16.0 batch

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -83,7 +83,8 @@ For historical post-MVP batch planning, see:
 
 ## Upcoming milestones
 
-- next implementation batch not defined yet
+- `v0.16.0`: theme authoring ergonomics
+  - evaluate optional SCSS support for theme authoring
 
 Tracked maintenance follow-up:
 
@@ -134,5 +135,4 @@ Tracked maintenance follow-up:
   - more helper functions/filters
   - stronger macro/partial conventions and examples
 - continue growing the layout theme ecosystem now that palette/font foundations are in place
-- evaluate optional SCSS support for theme authoring while keeping plain CSS as the default
 - consider multilingual support only after the single-language publishing model is more mature

--- a/site/content/roadmap.md
+++ b/site/content/roadmap.md
@@ -81,7 +81,11 @@ Ecosystem consistency and reusable site conventions:
 
 ## Next Up
 
-The next implementation batch has not been defined yet.
+### `v0.16.0`
+
+Theme authoring ergonomics:
+
+- optional SCSS support for theme authoring
 
 ## Tracked Follow-up
 


### PR DESCRIPTION
## Summary
- define `v0.16.0` as the next roadmap batch
- place SCSS evaluation into that batch
- keep multilingual support out of the active batch and leave Node 24 work as tracked follow-up

## Verification
- cargo run --quiet -- build (from `site/`)
