### PR TITLE
feat(styles): add optional scss support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,6 +28,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -312,6 +330,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "codemap"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e769b5c8c8283982a987c6e948e540254f1058d5a74b8794914d4ef5fc2a24"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,8 +576,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -594,6 +620,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "grass"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a68216437ef68f0738e48d6c7bb9e6e6a92237e001b03d838314b068f33c94"
+dependencies = [
+ "getrandom 0.2.17",
+ "grass_compiler",
+]
+
+[[package]]
+name = "grass_compiler"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d9e3df7f0222ce5184154973d247c591d9aadc28ce7a73c6cd31100c9facff6"
+dependencies = [
+ "codemap",
+ "indexmap",
+ "lasso",
+ "once_cell",
+ "phf",
+]
+
+[[package]]
 name = "gray_matter"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,6 +651,16 @@ dependencies = [
  "serde",
  "thiserror",
  "yaml-rust2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -877,6 +936,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lasso"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e14eda50a3494b3bf7b9ce51c52434a761e383d7238ce1dd5dcec2fbc13e9fb"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,6 +1186,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
+ "phf_macros",
  "phf_shared",
 ]
 
@@ -1139,6 +1208,19 @@ checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
  "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1350,6 +1432,7 @@ dependencies = [
  "axum",
  "chrono",
  "clap",
+ "grass",
  "gray_matter",
  "image",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,4 @@ toml = "1.0.6"
 toml_edit = "0.23.7"
 tower-http = { version = "0.6.8", features = ["fs"] }
 walkdir = "2.5.0"
+grass = { version = "0.13.4", default-features = false }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -83,6 +83,7 @@ Current behavior:
 - Validates internal Markdown links against generated routes and deep links when possible
 - Validates rendered route/output collisions
 - Validates generated `palette.css` would not collide with site or theme assets
+- Validates optional SCSS inputs when `themes/<theme>/static/style.scss` or `static/custom.scss` are used
 - Validates theme and user static asset paths would not collide
 - Exits with non-zero status when validation fails
 
@@ -169,6 +170,8 @@ Current behavior:
 - Exposes `site_font_faces_css` to templates for optional font-face injection
 - Exposes `site_analytics_head_html` to templates for opt-in analytics snippet output
 - Auto-includes `static/custom.css` in template context when present (`site_has_custom_css`)
+- Compiles optional `themes/<theme>/static/style.scss` into `dist/style.css`
+- Compiles optional `static/custom.scss` into `dist/custom.css`
 - Writes rendered pages to `dist/` using pretty URL output paths
 - Writes generated palette variables to `dist/palette.css`
 - Fails with a readable error if generated `palette.css` would collide with a user/theme asset

--- a/docs/implemented-features.md
+++ b/docs/implemented-features.md
@@ -406,10 +406,15 @@
 - `favicon.svg`
 - `apple-touch-icon.png`
 - optional `static/custom.css`
+- optional `static/custom.scss`
+- optional theme `static/style.scss`
+- SCSS validation during `rustipo check`
 
 ## Output Generation
 
 - pretty URL HTML output
+- compiled `dist/style.css` from optional theme SCSS
+- compiled `dist/custom.css` from optional site SCSS
 - generated `dist/palette.css`
 - generated `dist/rss.xml`
 - generated `dist/sitemap.xml`

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -25,6 +25,7 @@ Rustipo projects are organized around a simple model:
   static/
     favicon.svg
     custom.css (optional)
+    custom.scss (optional)
   themes/
     default/
       templates/
@@ -54,7 +55,7 @@ Rustipo projects are organized around a simple model:
   - `blog/` and `projects/` stay special one-level sections
 - `themes/`: layout themes
   - `templates/` contains reusable Tera templates
-  - `static/` contains theme CSS and theme assets
+  - `static/` contains theme CSS, optional `style.scss`, and theme assets
   - `theme.toml` contains theme metadata
   - local project themes live here when you want to override or add custom layouts
 - built-in themes are embedded in Rustipo and selectable without copying files into the project:
@@ -72,8 +73,9 @@ Rustipo projects are organized around a simple model:
   - `tokyonight-storm`
   - `tokyonight-moon`
 - `static/`: user-provided assets copied into the output
-  - images, fonts, JavaScript files, favicons, and optional `custom.css` belong here
-  - `static/custom.css` (optional) is loaded after theme CSS when present for user overrides
+  - images, fonts, JavaScript files, favicons, and optional `custom.css` or `custom.scss` belong here
+  - `static/custom.css` remains the plain CSS default for site overrides
+  - `static/custom.scss` is optional and compiles to `dist/custom.css`
 - `dist/`: generated static output (created by build step)
 
 ## Layout and typography configuration

--- a/docs/theme-contract.md
+++ b/docs/theme-contract.md
@@ -160,6 +160,7 @@ Generator responsibilities:
 - Validate required templates across the full inheritance chain
 - Render content through merged templates (child overrides parent files by relative path)
 - Copy merged theme static assets to output (child overrides parent files by relative path)
+- Optionally compile `static/style.scss` into `dist/style.css` when a theme opts in
 
 ## How Tera fits the workflow
 
@@ -207,7 +208,7 @@ Rustipo injects common site variables into template contexts, including:
   - `site_style.body_font`
   - `site_style.heading_font`
   - `site_style.mono_font`
-- `site_has_custom_css` (boolean, true when `static/custom.css` exists)
+- `site_has_custom_css` (boolean, true when `static/custom.css` or `static/custom.scss` exists)
 - `site_font_faces_css` (optional rendered `@font-face` rules for configured local fonts)
 
 `page_description` is the stable convenience field for theme metadata output. It resolves with this fallback order:
@@ -257,6 +258,14 @@ Rustipo also registers small Tera helpers for theme authors:
 
 Rustipo writes generated image derivatives into `dist/processed-images/` and reserves that output
 path so user or theme static assets cannot collide with it.
+
+Rustipo keeps plain CSS as the default styling path, but a theme can opt into SCSS authoring by
+placing `static/style.scss` in the theme root. Rustipo compiles that file into the same
+`dist/style.css` output path that plain CSS themes already use.
+
+Site authors can do the same for overrides with `static/custom.scss`, which compiles into
+`dist/custom.css`. Rustipo rejects `style.css` + `style.scss` or `custom.css` + `custom.scss`
+when both exist for the same target so the final output path stays unambiguous.
 
 Rustipo currently formalizes one built-in taxonomy:
 

--- a/site/content/reference/cli.md
+++ b/site/content/reference/cli.md
@@ -32,6 +32,8 @@ Creates a starter project with content, a local default theme, and starter confi
 ### `rustipo check`
 
 Validates config, content, palettes, themes, routes, asset paths, and internal links without writing `dist/`.
+It also validates optional `themes/<theme>/static/style.scss` and `static/custom.scss` inputs when
+those files are present.
 
 ### `rustipo dev`
 
@@ -40,6 +42,8 @@ Builds, serves, watches, and live-reloads the site during development.
 ### `rustipo build`
 
 Writes generated output into `dist/`.
+When a theme provides `static/style.scss` or a site provides `static/custom.scss`, Rustipo compiles
+them into `dist/style.css` and `dist/custom.css`.
 
 ### `rustipo serve`
 

--- a/site/content/reference/themes-and-palettes.md
+++ b/site/content/reference/themes-and-palettes.md
@@ -31,6 +31,13 @@ Rustipo currently ships these built-in themes:
 
 Local themes can still live under `themes/<name>/` when you want custom layouts or inheritance.
 
+Theme authors can keep using plain `style.css`, or opt into SCSS by adding
+`themes/<name>/static/style.scss`. Rustipo compiles that into the same `dist/style.css` output
+path, so templates do not need a different asset reference.
+
+Site-level overrides can follow the same pattern with `static/custom.scss`, which compiles into
+`dist/custom.css`.
+
 ## Built-In Palettes
 
 Rustipo currently ships these built-in palettes:

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -27,6 +27,11 @@ fn build_site_with_logging(verbose: bool, publication_mode: PublicationMode) -> 
         &prepared.theme.static_dirs,
     )?;
     crate::output::palette::write_palette_css("dist", &prepared.palette)?;
+    let compiled_styles = crate::output::styles::compile_optional_scss(
+        "static",
+        &prepared.theme.static_dirs,
+        "dist",
+    )?;
     let copied_assets = crate::output::assets::copy_assets_with_collision_check(
         "static",
         &prepared.theme.static_dirs,
@@ -52,6 +57,7 @@ fn build_site_with_logging(verbose: bool, publication_mode: PublicationMode) -> 
             "Generated palette CSS: dist/palette.css ({})",
             prepared.palette.id
         );
+        println!("Generated compiled styles: {}", compiled_styles);
         println!("Generated processed images: {}", generated_images);
         println!("Copied assets: {}", copied_assets);
         println!("Generated RSS items: {}", rss_items);

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -8,12 +8,15 @@ pub fn run() -> Result<()> {
         "static",
         &prepared.theme.static_dirs,
     )?;
+    let validated_styles =
+        crate::output::styles::validate_optional_scss("static", &prepared.theme.static_dirs)?;
     let asset_count = crate::output::assets::validate_assets_with_collision_check(
         "static",
         &prepared.theme.static_dirs,
     )?;
 
     println!("Validated rendered routes: {}", rendered_routes);
+    println!("Validated optional SCSS inputs: {}", validated_styles);
     println!("Validated asset paths: {}", asset_count);
     println!("Check completed: project inputs are valid.");
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -175,7 +175,7 @@ impl SiteConfig {
 
     pub fn has_custom_css(&self, project_root: impl AsRef<Path>) -> bool {
         let _ = self;
-        project_root.as_ref().join("static/custom.css").is_file()
+        crate::output::styles::has_custom_stylesheet(project_root)
     }
 
     pub fn analytics_head_html(&self) -> Option<String> {

--- a/src/output/assets.rs
+++ b/src/output/assets.rs
@@ -75,6 +75,9 @@ fn collect_relative_files(root: &Path) -> Result<HashSet<PathBuf>> {
                 )
             })?
             .to_path_buf();
+        if crate::output::styles::should_skip_asset_copy(&rel) {
+            continue;
+        }
         files.insert(rel);
     }
 
@@ -92,12 +95,29 @@ fn prepare_asset_maps<'a>(
     theme_static_dirs: &[PathBuf],
 ) -> Result<PreparedAssetMaps<'a>> {
     let user_files = collect_relative_files(user_static_dir)?;
+    let theme_style_is_compiled = crate::output::styles::theme_style_uses_scss(theme_static_dirs)?;
+    let user_custom_is_compiled = crate::output::styles::user_custom_uses_scss(user_static_dir)?;
     let mut theme_files = BTreeMap::new();
     for theme_dir in theme_static_dirs {
         let rel_files = collect_relative_files(theme_dir)?;
         for rel in rel_files {
+            if theme_style_is_compiled && rel == Path::new("style.css") {
+                continue;
+            }
             theme_files.insert(rel.clone(), theme_dir.join(rel));
         }
+    }
+
+    if theme_style_is_compiled && user_files.contains(Path::new("style.css")) {
+        bail!(
+            "asset path collision detected: style.css is reserved for compiled theme SCSS output"
+        );
+    }
+
+    if user_custom_is_compiled && theme_files.contains_key(Path::new("custom.css")) {
+        bail!(
+            "asset path collision detected: custom.css is reserved for compiled site SCSS output"
+        );
     }
 
     if let Some(rel) = user_files.iter().find(|rel| theme_files.contains_key(*rel)) {
@@ -223,5 +243,94 @@ mod tests {
         assert_eq!(copied, 1);
         let written = fs::read_to_string(dist.join("style.css")).expect("style should exist");
         assert_eq!(written, "child");
+    }
+
+    #[test]
+    fn skips_scss_sources_when_copying_assets() {
+        let dir = tempdir().expect("tempdir should be created");
+        let root = dir.path();
+
+        let user_static = root.join("static");
+        let theme_static = root.join("themes/default/static");
+        let dist = root.join("dist");
+
+        fs::create_dir_all(&user_static).expect("user static should be created");
+        fs::create_dir_all(&theme_static).expect("theme static should be created");
+
+        fs::write(user_static.join("custom.scss"), "body { color: red; }")
+            .expect("scss should be written");
+        fs::write(theme_static.join("style.scss"), "body { color: blue; }")
+            .expect("scss should be written");
+        fs::write(theme_static.join("logo.svg"), "<svg/>").expect("svg should be written");
+
+        let copied = copy_assets_with_collision_check(
+            &user_static,
+            std::slice::from_ref(&theme_static),
+            &dist,
+        )
+        .expect("asset copy should succeed");
+
+        assert_eq!(copied, 1);
+        assert!(dist.join("logo.svg").is_file());
+        assert!(!dist.join("custom.scss").exists());
+        assert!(!dist.join("style.scss").exists());
+    }
+
+    #[test]
+    fn child_theme_scss_overrides_parent_style_css() {
+        let dir = tempdir().expect("tempdir should be created");
+        let root = dir.path();
+
+        let user_static = root.join("static");
+        let parent_static = root.join("themes/base/static");
+        let child_static = root.join("themes/child/static");
+        let dist = root.join("dist");
+
+        fs::create_dir_all(&parent_static).expect("parent static should be created");
+        fs::create_dir_all(&child_static).expect("child static should be created");
+
+        fs::write(parent_static.join("style.css"), "base").expect("base asset should be written");
+        fs::write(child_static.join("style.scss"), "body { color: blue; }")
+            .expect("child scss should be written");
+
+        let copied = copy_assets_with_collision_check(
+            &user_static,
+            &[parent_static.clone(), child_static.clone()],
+            &dist,
+        )
+        .expect("asset copy should succeed");
+
+        assert_eq!(copied, 0);
+        assert!(!dist.join("style.css").exists());
+    }
+
+    #[test]
+    fn fails_when_user_style_css_conflicts_with_compiled_theme_scss() {
+        let dir = tempdir().expect("tempdir should be created");
+        let root = dir.path();
+
+        let user_static = root.join("static");
+        let theme_static = root.join("themes/default/static");
+        let dist = root.join("dist");
+
+        fs::create_dir_all(&user_static).expect("user static should be created");
+        fs::create_dir_all(&theme_static).expect("theme static should be created");
+
+        fs::write(user_static.join("style.css"), "user").expect("user css should be written");
+        fs::write(theme_static.join("style.scss"), "body { color: blue; }")
+            .expect("theme scss should be written");
+
+        let error = copy_assets_with_collision_check(
+            &user_static,
+            std::slice::from_ref(&theme_static),
+            &dist,
+        )
+        .expect_err("collision should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("style.css is reserved for compiled theme SCSS output")
+        );
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -5,4 +5,5 @@ pub mod robots;
 pub mod rss;
 pub mod search;
 pub mod sitemap;
+pub mod styles;
 pub mod writer;

--- a/src/output/styles.rs
+++ b/src/output/styles.rs
@@ -1,0 +1,277 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+
+const THEME_STYLE_CSS: &str = "style.css";
+const THEME_STYLE_SCSS: &str = "style.scss";
+const USER_CUSTOM_CSS: &str = "custom.css";
+const USER_CUSTOM_SCSS: &str = "custom.scss";
+
+pub fn compile_optional_scss(
+    user_static_dir: impl AsRef<Path>,
+    theme_static_dirs: &[PathBuf],
+    dist_dir: impl AsRef<Path>,
+) -> Result<usize> {
+    let dist_dir = dist_dir.as_ref();
+    let mut generated = 0;
+
+    if let Some(source) = resolve_theme_style_source(theme_static_dirs)? {
+        generated += compile_if_scss(&source, dist_dir.join(THEME_STYLE_CSS), "theme style")?;
+    }
+
+    if let Some(source) = resolve_user_custom_source(user_static_dir.as_ref())? {
+        generated += compile_if_scss(&source, dist_dir.join(USER_CUSTOM_CSS), "custom style")?;
+    }
+
+    Ok(generated)
+}
+
+pub fn validate_optional_scss(
+    user_static_dir: impl AsRef<Path>,
+    theme_static_dirs: &[PathBuf],
+) -> Result<usize> {
+    let mut compiled = 0;
+
+    if let Some(source) = resolve_theme_style_source(theme_static_dirs)? {
+        compiled += validate_if_scss(&source, "theme style")?;
+    }
+
+    if let Some(source) = resolve_user_custom_source(user_static_dir.as_ref())? {
+        compiled += validate_if_scss(&source, "custom style")?;
+    }
+
+    Ok(compiled)
+}
+
+pub fn should_skip_asset_copy(relative_path: &Path) -> bool {
+    relative_path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("scss"))
+}
+
+pub fn has_custom_stylesheet(project_root: impl AsRef<Path>) -> bool {
+    let static_dir = project_root.as_ref().join("static");
+    static_dir.join(USER_CUSTOM_CSS).is_file() || static_dir.join(USER_CUSTOM_SCSS).is_file()
+}
+
+pub fn theme_style_uses_scss(theme_static_dirs: &[PathBuf]) -> Result<bool> {
+    Ok(matches!(
+        resolve_theme_style_source(theme_static_dirs)?,
+        Some(StyleSource::Scss(_))
+    ))
+}
+
+pub fn user_custom_uses_scss(user_static_dir: impl AsRef<Path>) -> Result<bool> {
+    Ok(matches!(
+        resolve_user_custom_source(user_static_dir.as_ref())?,
+        Some(StyleSource::Scss(_))
+    ))
+}
+
+#[derive(Clone)]
+enum StyleSource {
+    Css,
+    Scss(PathBuf),
+}
+
+fn resolve_theme_style_source(theme_static_dirs: &[PathBuf]) -> Result<Option<StyleSource>> {
+    let mut selected = None;
+
+    for dir in theme_static_dirs {
+        if let Some(source) =
+            resolve_target_source(dir, THEME_STYLE_CSS, THEME_STYLE_SCSS, "theme style")?
+        {
+            selected = Some(source);
+        }
+    }
+
+    Ok(selected)
+}
+
+fn resolve_user_custom_source(user_static_dir: &Path) -> Result<Option<StyleSource>> {
+    resolve_target_source(
+        user_static_dir,
+        USER_CUSTOM_CSS,
+        USER_CUSTOM_SCSS,
+        "custom style",
+    )
+}
+
+fn resolve_target_source(
+    root: &Path,
+    css_name: &str,
+    scss_name: &str,
+    label: &str,
+) -> Result<Option<StyleSource>> {
+    let css_path = root.join(css_name);
+    let scss_path = root.join(scss_name);
+    let has_css = css_path.is_file();
+    let has_scss = scss_path.is_file();
+
+    if has_css && has_scss {
+        bail!(
+            "{label} conflict: '{}' and '{}' both exist; keep plain CSS as the default path by using only one",
+            css_path.display(),
+            scss_path.display()
+        );
+    }
+
+    if has_scss {
+        return Ok(Some(StyleSource::Scss(scss_path)));
+    }
+
+    if has_css {
+        let _ = css_path;
+        return Ok(Some(StyleSource::Css));
+    }
+
+    Ok(None)
+}
+
+fn compile_if_scss(source: &StyleSource, dst: PathBuf, label: &str) -> Result<usize> {
+    match source {
+        StyleSource::Css => Ok(0),
+        StyleSource::Scss(path) => {
+            let css = compile_scss(path, label)?;
+            if let Some(parent) = dst.parent() {
+                fs::create_dir_all(parent).with_context(|| {
+                    format!(
+                        "failed to create compiled stylesheet output path: {}",
+                        parent.display()
+                    )
+                })?;
+            }
+            fs::write(&dst, css).with_context(|| {
+                format!(
+                    "failed to write compiled stylesheet '{}' to '{}'",
+                    path.display(),
+                    dst.display()
+                )
+            })?;
+            Ok(1)
+        }
+    }
+}
+
+fn validate_if_scss(source: &StyleSource, label: &str) -> Result<usize> {
+    match source {
+        StyleSource::Css => Ok(0),
+        StyleSource::Scss(path) => {
+            let _ = compile_scss(path, label)?;
+            Ok(1)
+        }
+    }
+}
+
+fn compile_scss(path: &Path, label: &str) -> Result<String> {
+    grass::from_path(path, &grass::Options::default())
+        .with_context(|| format!("failed to compile {label} SCSS: {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::Path;
+
+    use tempfile::tempdir;
+
+    use super::{
+        compile_optional_scss, has_custom_stylesheet, should_skip_asset_copy,
+        theme_style_uses_scss, user_custom_uses_scss, validate_optional_scss,
+    };
+
+    #[test]
+    fn compiles_theme_style_scss_to_style_css() {
+        let dir = tempdir().expect("tempdir should be created");
+        let theme_static = dir.path().join("themes/default/static");
+        let dist = dir.path().join("dist");
+        fs::create_dir_all(&theme_static).expect("theme static should be created");
+        fs::write(theme_static.join("_tokens.scss"), "$bg: #123456;")
+            .expect("scss partial should be written");
+        fs::write(
+            theme_static.join("style.scss"),
+            "@use \"tokens\";\nbody { color: tokens.$bg; }",
+        )
+        .expect("scss file should be written");
+
+        let generated = compile_optional_scss(dir.path().join("static"), &[theme_static], &dist)
+            .expect("scss compilation should succeed");
+
+        assert_eq!(generated, 1);
+        let css = fs::read_to_string(dist.join("style.css")).expect("compiled css should exist");
+        assert!(css.contains("color: #123456;"));
+    }
+
+    #[test]
+    fn validates_scss_without_writing_output() {
+        let dir = tempdir().expect("tempdir should be created");
+        let theme_static = dir.path().join("themes/default/static");
+        fs::create_dir_all(&theme_static).expect("theme static should be created");
+        fs::write(theme_static.join("style.scss"), "body { color: red; }")
+            .expect("scss file should be written");
+
+        let validated = validate_optional_scss(dir.path().join("static"), &[theme_static])
+            .expect("scss validation should succeed");
+
+        assert_eq!(validated, 1);
+        assert!(
+            !dir.path().join("dist/style.css").exists(),
+            "validation should not write compiled output"
+        );
+    }
+
+    #[test]
+    fn fails_when_css_and_scss_exist_for_same_target() {
+        let dir = tempdir().expect("tempdir should be created");
+        let static_dir = dir.path().join("static");
+        fs::create_dir_all(&static_dir).expect("static dir should be created");
+        fs::write(static_dir.join("custom.css"), "body{}").expect("css should be written");
+        fs::write(static_dir.join("custom.scss"), "body { color: red; }")
+            .expect("scss should be written");
+
+        let error = validate_optional_scss(&static_dir, &[]).expect_err("conflict should fail");
+        assert!(error.to_string().contains("custom style conflict"));
+    }
+
+    #[test]
+    fn detects_custom_scss_as_custom_stylesheet() {
+        let dir = tempdir().expect("tempdir should be created");
+        let static_dir = dir.path().join("static");
+        fs::create_dir_all(&static_dir).expect("static dir should be created");
+        fs::write(static_dir.join("custom.scss"), "body { color: red; }")
+            .expect("scss should be written");
+
+        assert!(has_custom_stylesheet(dir.path()));
+    }
+
+    #[test]
+    fn skips_scss_sources_when_copying_assets() {
+        assert!(should_skip_asset_copy(Path::new("style.scss")));
+        assert!(should_skip_asset_copy(Path::new("styles/_tokens.scss")));
+        assert!(!should_skip_asset_copy(Path::new("style.css")));
+    }
+
+    #[test]
+    fn detects_when_theme_style_output_is_reserved_for_scss() {
+        let dir = tempdir().expect("tempdir should be created");
+        let theme_static = dir.path().join("themes/default/static");
+        fs::create_dir_all(&theme_static).expect("theme static should be created");
+        fs::write(theme_static.join("style.scss"), "body { color: red; }")
+            .expect("scss file should be written");
+
+        assert!(theme_style_uses_scss(&[theme_static]).expect("detection should succeed"));
+    }
+
+    #[test]
+    fn detects_when_user_custom_output_is_reserved_for_scss() {
+        let dir = tempdir().expect("tempdir should be created");
+        let static_dir = dir.path().join("static");
+        fs::create_dir_all(&static_dir).expect("static dir should be created");
+        fs::write(static_dir.join("custom.scss"), "body { color: red; }")
+            .expect("scss file should be written");
+
+        assert!(user_custom_uses_scss(&static_dir).expect("detection should succeed"));
+    }
+}

--- a/tests/cli_flow.rs
+++ b/tests/cli_flow.rs
@@ -155,6 +155,7 @@ fn check_succeeds_for_new_scaffold() {
 
     let stdout = String::from_utf8_lossy(&check_output.stdout);
     assert!(stdout.contains("Validated rendered routes:"));
+    assert!(stdout.contains("Validated optional SCSS inputs:"));
     assert!(stdout.contains("Validated asset paths:"));
     assert!(stdout.contains("Check completed: project inputs are valid."));
     assert!(
@@ -235,6 +236,77 @@ fn check_supports_resize_helper_without_writing_dist() {
     assert!(
         !project.join("dist").exists(),
         "check should not write dist output"
+    );
+}
+
+#[test]
+fn build_supports_theme_style_scss() {
+    let dir = tempdir().expect("tempdir should be created");
+    let root = dir.path();
+
+    let new_output = run_cli(root, &["new", "my-site"]);
+    assert!(
+        new_output.status.success(),
+        "new failed: {}",
+        String::from_utf8_lossy(&new_output.stderr)
+    );
+
+    let project = root.join("my-site");
+    fs::remove_file(project.join("themes/default/static/style.css"))
+        .expect("default css should be removable");
+    fs::write(
+        project.join("themes/default/static/_tokens.scss"),
+        "$surface: #224466;",
+    )
+    .expect("scss partial should be written");
+    fs::write(
+        project.join("themes/default/static/style.scss"),
+        "@use \"tokens\";\nbody { background: tokens.$surface; }",
+    )
+    .expect("scss file should be written");
+
+    let build_output = run_cli(&project, &["build"]);
+    assert!(
+        build_output.status.success(),
+        "build failed: {}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+
+    let style_css =
+        fs::read_to_string(project.join("dist/style.css")).expect("compiled style should exist");
+    assert!(style_css.contains("background: #224466;"));
+    assert!(!project.join("dist/style.scss").exists());
+    assert!(!project.join("dist/_tokens.scss").exists());
+}
+
+#[test]
+fn check_fails_for_invalid_theme_style_scss() {
+    let dir = tempdir().expect("tempdir should be created");
+    let root = dir.path();
+
+    let new_output = run_cli(root, &["new", "my-site"]);
+    assert!(
+        new_output.status.success(),
+        "new failed: {}",
+        String::from_utf8_lossy(&new_output.stderr)
+    );
+
+    let project = root.join("my-site");
+    fs::remove_file(project.join("themes/default/static/style.css"))
+        .expect("default css should be removable");
+    fs::write(
+        project.join("themes/default/static/style.scss"),
+        "body { color: $missing; }",
+    )
+    .expect("invalid scss should be written");
+
+    let output = run_cli(&project, &["check"]);
+    assert!(!output.status.success(), "check should fail");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("failed to compile theme style SCSS"),
+        "unexpected stderr: {stderr}"
     );
 }
 


### PR DESCRIPTION
## Summary
- add optional SCSS compilation for theme `style.scss` and site `custom.scss`
- validate SCSS during `rustipo check` and reserve generated output paths during asset copying
- document the SCSS authoring flow in repo docs and the docs site

## Testing
- cargo test -q
- cargo run --quiet -- build (from `site/`)

Closes #53