### PR TITLE
docs(site): add contributor guide

### DIFF
--- a/site/content/guides/contributing.md
+++ b/site/content/guides/contributing.md
@@ -1,0 +1,120 @@
+---
+title: Contributing
+summary: Learn how to make focused contributions to Rustipo across code, docs, examples, and themes.
+order: 4
+---
+
+# Contributing
+
+Rustipo is a compact open-source project, so focused improvements go a long way. Contributions are
+welcome across:
+
+- core behavior
+- documentation
+- example sites
+- themes and palettes
+- tests and regression coverage
+
+## Best First Reads
+
+If you are new to the repository, these pages help you orient quickly:
+
+- [README on GitHub](https://github.com/fcendesu/rustipo/blob/master/README.md)
+- [Contributing guide on GitHub](https://github.com/fcendesu/rustipo/blob/master/CONTRIBUTING.md)
+- [Roadmap](/roadmap/)
+- [Project structure on GitHub](https://github.com/fcendesu/rustipo/blob/master/docs/project-structure.md)
+- [Themes and palettes](/reference/themes-and-palettes/)
+
+## Local Setup
+
+Clone the repository and run Rustipo from the workspace:
+
+```bash
+git clone https://github.com/fcendesu/rustipo.git
+cd rustipo
+cargo run -- new my-site
+cd my-site
+../target/debug/rustipo dev
+```
+
+That gives you a quick way to verify the tool locally while still working against the repository
+version.
+
+## Useful In-Repo Projects
+
+Rustipo includes a few real projects you can use while changing behavior:
+
+- `examples/basic-portfolio/` for the starter personal-site shape
+- `examples/journal/` for a blog-focused editorial shape
+- `examples/knowledge-base/` for a docs-and-notes shape
+- `site/` for the published documentation site itself
+
+## Recommended Contributor Loop
+
+From the repository root:
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test -q
+```
+
+If your change affects the docs site, also verify:
+
+```bash
+cd site
+cargo run --quiet -- build
+```
+
+If your change affects packaging or release readiness, verify crate contents too:
+
+```bash
+cargo package --allow-dirty --list
+```
+
+## What Makes A Strong PR
+
+- keep the change focused and reviewable
+- keep behavior changes and refactors separate when practical
+- add or update tests for changed behavior
+- update docs when user-facing behavior changes
+- explain what changed and why in the PR description
+
+Rustipo uses Conventional Commits:
+
+```text
+<type>(<scope>): <subject>
+```
+
+Examples:
+
+- `feat(content): add shortcode asset collection`
+- `fix(output): honor base_url subpaths`
+- `docs(repo): improve contributor onboarding`
+
+## Docs Contributions
+
+Docs-only changes are welcome.
+
+When behavior changes, it is usually worth updating both:
+
+- repository docs under `docs/`
+- the published docs site under `site/content/`
+
+That keeps GitHub readers and docs-site readers on the same page.
+
+## Maintainer Notes
+
+Normal contribution PRs should not hand-edit release version files or `CHANGELOG.md`.
+
+Maintainers handle release preparation with Release Please. If you need the maintainer-specific
+workflow, see:
+
+- [Release and publish workflow](https://github.com/fcendesu/rustipo/blob/master/docs/release.md)
+- [CI notes](https://github.com/fcendesu/rustipo/blob/master/docs/ci.md)
+
+## Related Pages
+
+- [Getting started](/guides/getting-started/)
+- [Build the docs site](/guides/building-the-docs-site/)
+- [Roadmap](/roadmap/)

--- a/site/content/guides/index.md
+++ b/site/content/guides/index.md
@@ -10,12 +10,14 @@ Rustipo's guides are the best place to start when you want a practical path thro
 - [Getting started](/guides/getting-started/)
 - [Building the docs site](/guides/building-the-docs-site/)
 - [Interactive embeds](/guides/interactive-embeds/)
+- [Contributing](/guides/contributing/)
 
 ## Suggested order
 
 1. Start with [Getting started](/guides/getting-started/) to create and preview a site locally.
 2. Continue to [Interactive embeds](/guides/interactive-embeds/) if you want to reuse demos and iframe-style embeds from Markdown.
 3. Continue to [Building the docs site](/guides/building-the-docs-site/) if you want to understand how Rustipo's own documentation project is structured.
+4. Continue to [Contributing](/guides/contributing/) if you want the practical loop for sending focused changes back to Rustipo itself.
 
 ## What guides focus on
 
@@ -23,3 +25,4 @@ Rustipo's guides are the best place to start when you want a practical path thro
 - the relationship between content, themes, and palettes
 - reusable embed authoring patterns
 - how the in-repo docs project is organized and published
+- how to contribute changes back to the Rustipo repository

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -14,6 +14,7 @@ Rustipo is a Markdown-first static site generator for blogs, notes, docs, and pe
 
 - [Get started](/guides/getting-started/)
 - [Build the docs site](/guides/building-the-docs-site/)
+- [Contributing to Rustipo](/guides/contributing/)
 - [CLI reference](/reference/cli/)
 - [Content model](/reference/content-model/)
 - [Themes and palettes](/reference/themes-and-palettes/)


### PR DESCRIPTION
## Summary
- add a contributor guide to the published docs site
- link it from the docs homepage and guides landing page
- mirror the practical contributor loop from the repo docs in docs-site form

## Testing
- cargo run --quiet -- build (from `site/`)
