### PR TITLE
chore(repo): add community contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,55 @@
+name: Bug report
+description: Report broken behavior, regressions, or incorrect output in Rustipo.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please include enough detail for someone else to reproduce it.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is going wrong?
+      placeholder: A short description of the bug or regression.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Steps, commands, or content needed to reproduce the problem.
+      placeholder: |
+        1. Run ...
+        2. Open ...
+        3. Notice ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect Rustipo to do instead?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include Rustipo version, install method, OS, and anything else relevant.
+      placeholder: |
+        - Rustipo version:
+        - Install method:
+        - OS:
+        - Rust version:
+    validations:
+      required: false
+  - type: textarea
+    id: notes
+    attributes:
+      label: Extra context
+      description: Logs, screenshots, sample config, or any context that would help triage.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Read the docs
+    url: https://fcendesu.github.io/rustipo/
+    about: Check the published docs site for current guides and reference material before opening an issue.
+  - name: Review the roadmap
+    url: https://github.com/fcendesu/rustipo/blob/master/docs/roadmap.md
+    about: Check the roadmap if you want to see whether an idea is already planned.

--- a/.github/ISSUE_TEMPLATE/docs-improvement.yml
+++ b/.github/ISSUE_TEMPLATE/docs-improvement.yml
@@ -1,0 +1,32 @@
+name: Docs improvement
+description: Suggest a missing, confusing, or inaccurate documentation change.
+title: "[Docs]: "
+labels:
+  - docs
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Rustipo's documentation.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is unclear or missing?
+      description: Explain what was confusing, inaccurate, or absent.
+    validations:
+      required: true
+  - type: textarea
+    id: location
+    attributes:
+      label: Where did you hit it?
+      description: Link the page, file, command, or guide that needs work.
+      placeholder: README, docs/cli.md, published docs site guide, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested improvement
+      description: What explanation, example, or wording would make it better?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Suggest a new capability or improvement for Rustipo.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea. Feature requests are easiest to evaluate when they stay close to a concrete authoring, theme, or publishing problem.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What workflow, limitation, or pain point are you trying to improve?
+      placeholder: I want Rustipo to make it easier to ...
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What behavior, command, config, or template support would help?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What are you doing today instead, or what other approaches did you consider?
+    validations:
+      required: false
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope notes
+      description: Mention whether this affects content authoring, themes, deployment, docs, or release tooling.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+
+- what changed
+- why it changed
+- any notable tradeoffs or follow-up work
+
+## Testing
+
+- [ ] `cargo fmt --all`
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
+- [ ] `cargo test -q`
+- [ ] docs-only change
+- [ ] not run locally, explained below
+
+## Docs impact
+
+- [ ] docs updated
+- [ ] docs not needed
+
+## Notes
+
+- link related issues or follow-up work
+- mention example-site, docs-site, or release-impact changes when relevant


### PR DESCRIPTION
## Summary
- add GitHub issue templates for bug reports, feature requests, and docs improvements
- add issue-template config to guide people toward docs and roadmap links
- add a PR template with lightweight summary, testing, and docs-impact prompts

## Testing
- ruby -e 'Dir[".github/ISSUE_TEMPLATE/*.yml"].each { |f| YAML.load_file(f) }; puts "issue templates ok"' -ryaml
