### PR TITLE
docs(repo): add security policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@ Rustipo is still a compact project, so clear, focused changes help a lot. Small 
 docs, examples, themes, tests, and core behavior are all valuable contributions.
 
 Please also read the project's [Code of Conduct](./CODE_OF_CONDUCT.md).
+If you need to report a security issue, use the private path described in [SECURITY.md](./SECURITY.md)
+instead of filing a normal public issue first.
 
 ## Good starting points
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ framework, Rustipo is meant to feel approachable.
 
 - [Published docs site](https://fcendesu.github.io/rustipo/)
 - [Contributing guide](./CONTRIBUTING.md)
+- [Security policy](./SECURITY.md)
 - [Roadmap](./docs/roadmap.md)
 - [Example sites](#example-sites)
 - [GitHub Releases](https://github.com/fcendesu/rustipo/releases)
@@ -288,6 +289,7 @@ Start here:
 
 - [Contributing guide](./CONTRIBUTING.md)
 - [Code of Conduct](./CODE_OF_CONDUCT.md)
+- [Security policy](./SECURITY.md)
 - [Roadmap](./docs/roadmap.md)
 - [published docs site](https://fcendesu.github.io/rustipo/)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+Rustipo is distributed as an open-source static site generator through crates.io and GitHub
+release binaries. If you believe you have found a security issue, please report it privately
+instead of opening a public GitHub issue first.
+
+## Reporting A Vulnerability
+
+Please contact the maintainer privately through [GitHub](https://github.com/fcendesu).
+
+When possible, include:
+
+- a short description of the issue
+- the affected Rustipo version
+- steps to reproduce or a proof of concept
+- potential impact
+- any suggested mitigation or patch ideas
+
+## Public Issues
+
+For suspected security problems, avoid filing a normal public issue before the maintainer has had a
+chance to review it privately.
+
+Public issues are still fine for:
+
+- general hardening ideas
+- dependency update suggestions
+- non-sensitive maintenance work
+
+## Scope
+
+Useful reports usually involve things like:
+
+- unsafe generated output that could put site owners or readers at risk
+- release or packaging issues that could affect distributed binaries or crates
+- security-sensitive workflow or deployment behavior
+
+## Response Expectations
+
+Rustipo is a small maintained project, so response times may vary. Reports will be reviewed in good
+faith and handled as carefully as possible.


### PR DESCRIPTION
## Summary
- add a lightweight `SECURITY.md` for private vulnerability reporting guidance
- link the security policy from README and CONTRIBUTING
- keep the policy scoped to the needs of a small maintained OSS project

## Testing
- docs-only change

Closes #177
