### PR TITLE
docs(site): add llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ What each part is for:
 ## Documentation
 
 - [published docs site](https://fcendesu.github.io/rustipo/)
+- [published llms.txt](https://fcendesu.github.io/rustipo/llms.txt)
 - [docs site source](./site)
 - [Contributing guide](./CONTRIBUTING.md)
 - [Code of Conduct](./CODE_OF_CONDUCT.md)

--- a/docs/implemented-features.md
+++ b/docs/implemented-features.md
@@ -33,6 +33,7 @@
 - GitHub release generation
 - GitHub release notes synchronization
 - published docs site
+- published docs-site `llms.txt`
 - prebuilt release archives
   - `x86_64-unknown-linux-gnu`
   - `x86_64-apple-darwin`
@@ -487,6 +488,7 @@
 - GitHub Pages workflow generation
 - workflow overwrite protection
 - docs site GitHub Pages publish workflow
+- curated docs-site `llms.txt` for LLM-friendly discovery
 
 ## Validation and Failure Handling
 

--- a/site/content/guides/building-the-docs-site.md
+++ b/site/content/guides/building-the-docs-site.md
@@ -55,6 +55,7 @@ The docs site is published from this repository with GitHub Pages.
 
 - pushes to `master` rebuild and deploy the site automatically
 - the published URL is `https://fcendesu.github.io/rustipo/`
+- the docs site also publishes `https://fcendesu.github.io/rustipo/llms.txt` as a curated LLM-friendly entry point
 - the workflow lives at `.github/workflows/docs-site.yml`
 
 ## What This Site Should Showcase

--- a/site/static/llms.txt
+++ b/site/static/llms.txt
@@ -1,0 +1,31 @@
+# Rustipo
+
+> Rustipo is a Markdown-first static site generator written in Rust for blogs, docs, notes, and personal sites. It uses Tera templates for layout and keeps theme structure separate from palette-driven styling.
+
+Use the published docs site as the primary source for end-user workflows and feature behavior.
+Use the GitHub repository docs for contributor guidance, release workflow details, and repository-specific context.
+
+## Start Here
+
+- [Rustipo docs home](https://fcendesu.github.io/rustipo/): High-level overview of the project and its strengths.
+- [Getting started](https://fcendesu.github.io/rustipo/guides/getting-started/): Install Rustipo, create a site, choose a palette, and preview locally.
+- [CLI reference](https://fcendesu.github.io/rustipo/reference/cli/): Commands, deployment helpers, and recommended local workflow.
+
+## Core Concepts
+
+- [Content model](https://fcendesu.github.io/rustipo/reference/content-model/): Markdown organization, frontmatter, routes, taxonomies, and authoring behavior.
+- [Themes and palettes](https://fcendesu.github.io/rustipo/reference/themes-and-palettes/): Built-in themes, palette selection, theme contracts, and image helper support.
+- [Examples](https://fcendesu.github.io/rustipo/examples/): Representative site shapes for personal sites, journals, and knowledge bases.
+
+## Docs And Deployment
+
+- [Build the docs site](https://fcendesu.github.io/rustipo/guides/building-the-docs-site/): How the in-repo documentation project is built and published.
+- [Roadmap](https://fcendesu.github.io/rustipo/roadmap/): Recent releases, current direction, and tracked follow-up work.
+- [GitHub releases](https://github.com/fcendesu/rustipo/releases): Release notes, binaries, and tagged versions.
+
+## Contributing And Project Metadata
+
+- [Contributing guide](https://fcendesu.github.io/rustipo/guides/contributing/): How to contribute code, docs, and examples back to Rustipo.
+- [Repository README](https://github.com/fcendesu/rustipo/blob/master/README.md): Project-facing install story, examples, and contributor entry points.
+- [CONTRIBUTING.md](https://github.com/fcendesu/rustipo/blob/master/CONTRIBUTING.md): Repository contributor expectations and local workflow.
+- [Security policy](https://github.com/fcendesu/rustipo/blob/master/SECURITY.md): Private reporting guidance for vulnerabilities.


### PR DESCRIPTION
## Summary
- add a curated `llms.txt` to the published docs site
- point it at the most useful Rustipo docs, examples, and contributor pages
- document the new published `llms.txt` surface in README and docs-site publishing docs

## Testing
- cargo run --quiet -- build (from `site/`)
