### PR TITLE
docs(roadmap): note upcoming 0.15.0 release

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -87,7 +87,14 @@ For historical post-MVP batch planning, see:
 
 ## Upcoming milestones
 
-- next batch not defined yet
+- next release: `v0.15.0`
+  - aggregate the completed post-`v0.14.0` work into the next published crate release
+  - highlights:
+    - generic analytics configuration
+    - optional SCSS support for theme authoring
+    - extensible frontmatter data for template-driven pages
+    - docs-site landing and information-architecture improvements
+- next roadmap batch not defined yet
 
 Tracked maintenance follow-up:
 


### PR DESCRIPTION
## Summary
- note that the next published crate release is v0.15.0
- summarize the major post-v0.14.0 work queued for that release

## Verification
- docs-only change
