### PR TITLE
fix(ci): support manual release asset backfills

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,6 +2,11 @@ name: Release Please
 
 on:
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing release tag to build and publish assets for
+        required: false
+        type: string
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -10,6 +15,7 @@ permissions: {}
 
 jobs:
   release-please:
+    if: ${{ github.event.inputs.release_tag == '' }}
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -49,13 +55,29 @@ jobs:
               body: process.env.RELEASE_BODY,
             });
 
+  existing-release-target:
+    if: ${{ github.event.inputs.release_tag != '' }}
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.target.outputs.release_created }}
+      tag_name: ${{ steps.target.outputs.tag_name }}
+    steps:
+      - name: Use existing release tag
+        id: target
+        run: |
+          echo "release_created=true" >> "$GITHUB_OUTPUT"
+          echo "tag_name=${{ github.event.inputs.release_tag }}" >> "$GITHUB_OUTPUT"
+
   release-binaries:
     name: Build release binaries (${{ matrix.target }})
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' && needs.release-please.outputs.tag_name != '' }}
+    needs:
+      - release-please
+      - existing-release-target
+    if: ${{ (needs.release-please.outputs.release_created == 'true' || needs.existing-release-target.outputs.release_created == 'true') && (needs.release-please.outputs.tag_name != '' || needs.existing-release-target.outputs.tag_name != '') }}
     runs-on: ${{ matrix.runner }}
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+      RELEASE_TAG: ${{ needs.release-please.outputs.tag_name || needs.existing-release-target.outputs.tag_name }}
     permissions:
       contents: read
     strategy:
@@ -78,7 +100,7 @@ jobs:
       - name: Check out release tag
         uses: actions/checkout@v6
         with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -97,7 +119,6 @@ jobs:
         if: runner.os != 'Windows'
         shell: bash
         env:
-          RELEASE_TAG: ${{ needs.release-please.outputs.tag_name }}
           TARGET: ${{ matrix.target }}
           BINARY_NAME: ${{ matrix.binary_name }}
         run: |
@@ -113,7 +134,6 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         env:
-          RELEASE_TAG: ${{ needs.release-please.outputs.tag_name }}
           TARGET: ${{ matrix.target }}
           BINARY_NAME: ${{ matrix.binary_name }}
         run: |
@@ -128,7 +148,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: release-binary-${{ matrix.target }}
-          path: ${{ github.workspace }}/${{ needs.release-please.outputs.tag_name }}-${{ matrix.target }}.*
+          path: ${{ github.workspace }}/${{ env.RELEASE_TAG }}-${{ matrix.target }}.*
           if-no-files-found: error
 
   publish-release-assets:
@@ -136,10 +156,12 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - release-please
+      - existing-release-target
       - release-binaries
-    if: ${{ needs.release-please.outputs.release_created == 'true' && needs.release-please.outputs.tag_name != '' }}
+    if: ${{ (needs.release-please.outputs.release_created == 'true' || needs.existing-release-target.outputs.release_created == 'true') && (needs.release-please.outputs.tag_name != '' || needs.existing-release-target.outputs.tag_name != '') }}
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+      RELEASE_TAG: ${{ needs.release-please.outputs.tag_name || needs.existing-release-target.outputs.tag_name }}
     permissions:
       contents: write
     steps:
@@ -152,13 +174,11 @@ jobs:
 
       - name: Generate release checksums
         working-directory: release-assets
-        env:
-          RELEASE_TAG: ${{ needs.release-please.outputs.tag_name }}
         run: sha256sum * > "${RELEASE_TAG}-sha256sums.txt"
 
       - name: Upload release assets
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ needs.release-please.outputs.tag_name }}
+          tag_name: ${{ env.RELEASE_TAG }}
           files: release-assets/*
           fail_on_unmatched_files: true


### PR DESCRIPTION
## Summary\n- allow the release workflow to target an existing release tag on workflow_dispatch\n- reuse the same binary build and asset publish jobs for backfills\n- keep the normal Release Please path unchanged when no tag input is provided\n\n## Testing\n- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-please.yml"); puts "workflow yaml ok"'